### PR TITLE
Encode/decode to/from references to readers

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,79 +1,75 @@
+use std::io::Buffer;
 use std::io::Reader;
-use std::io::BufferedReader;
 use std::io::IoError;
+use std::io::IoResult;
 use std::io::OtherIoError;
 use serialize::Decoder;
 
-type EwResult = Result<(), IoError>;
-
-pub struct DecoderReader<R> {
-    reader: BufferedReader<R>
+pub struct DecoderReader<'a, R: 'a> {
+    reader: &'a mut R
 }
 
-impl <R: Reader> DecoderReader<R> {
-    pub fn new(r: R) -> DecoderReader<R> {
+impl<'a, R: Reader+Buffer> DecoderReader<'a, R> {
+    pub fn new(r: &'a mut R) -> DecoderReader<'a, R> {
         DecoderReader {
-            reader: BufferedReader::new(r)
+            reader: r
         }
     }
-    pub fn unwrap(self) -> R {
-        self.reader.unwrap()
-    }
 }
 
-impl <R: Reader> Decoder<IoError> for DecoderReader<R> {
-    fn read_nil(&mut self) -> Result<(), IoError> {
+impl<'a, R: Reader+Buffer> Decoder<IoError> for DecoderReader<'a, R> {
+    fn read_nil(&mut self) -> IoResult<()> {
         Ok(())
     }
-    fn read_uint(&mut self) -> Result<uint, IoError> {
+    fn read_uint(&mut self) -> IoResult<uint> {
         match self.reader.read_be_u64() {
             Ok(x) => Ok(x as uint),
             Err(e) => Err(e)
         }
     }
-    fn read_u64(&mut self) -> Result<u64, IoError> {
+    fn read_u64(&mut self) -> IoResult<u64> {
         self.reader.read_be_u64()
     }
-    fn read_u32(&mut self) -> Result<u32, IoError> {
+    fn read_u32(&mut self) -> IoResult<u32> {
         self.reader.read_be_u32()
     }
-    fn read_u16(&mut self) -> Result<u16, IoError> {
+    fn read_u16(&mut self) -> IoResult<u16> {
         self.reader.read_be_u16()
     }
-    fn read_u8(&mut self) -> Result<u8, IoError> {
+    fn read_u8(&mut self) -> IoResult<u8> {
         self.reader.read_u8()
     }
-    fn read_int(&mut self) -> Result<int, IoError> {
+    fn read_int(&mut self) -> IoResult<int> {
         self.reader.read_be_int()
     }
-    fn read_i64(&mut self) -> Result<i64, IoError> {
+    fn read_i64(&mut self) -> IoResult<i64> {
         self.reader.read_be_i64()
     }
-    fn read_i32(&mut self) -> Result<i32, IoError> {
+    fn read_i32(&mut self) -> IoResult<i32> {
         self.reader.read_be_i32()
     }
-    fn read_i16(&mut self) -> Result<i16, IoError> {
+    fn read_i16(&mut self) -> IoResult<i16> {
         self.reader.read_be_i16()
     }
-    fn read_i8(&mut self) -> Result<i8, IoError> {
+    fn read_i8(&mut self) -> IoResult<i8> {
         self.reader.read_i8()
     }
-    fn read_bool(&mut self) -> Result<bool, IoError> {
+    fn read_bool(&mut self) -> IoResult<bool> {
         match try!(self.reader.read_i8()) {
             1 => Ok(true),
             _ => Ok(false)
         }
     }
-    fn read_f64(&mut self) -> Result<f64, IoError> {
+    fn read_f64(&mut self) -> IoResult<f64> {
         self.reader.read_be_f64()
     }
-    fn read_f32(&mut self) -> Result<f32, IoError> {
+    fn read_f32(&mut self) -> IoResult<f32> {
         self.reader.read_be_f32()
     }
-    fn read_char(&mut self) -> Result<char, IoError> {
+    fn read_char(&mut self) -> IoResult<char> {
         self.reader.read_char()
     }
-    fn read_str(&mut self) -> Result<String, IoError> {
+    fn read_str(&mut self) -> IoResult<String> {
         let len = try!(self.read_uint());
         let mut vector = Vec::with_capacity(len as uint);
         for _ in range(0, len) {
@@ -82,83 +78,83 @@ impl <R: Reader> Decoder<IoError> for DecoderReader<R> {
         Ok(String::from_utf8(vector).unwrap())
     }
     fn read_enum<T>(&mut self, _: &str,
-    f: |&mut DecoderReader<R>| -> Result<T, IoError>) -> Result<T, IoError> {
+    f: |&mut DecoderReader<'a, R>| -> IoResult<T>) -> IoResult<T> {
         f(self)
     }
     fn read_enum_variant<T>(&mut self, _: &[&str],
-    f: |&mut DecoderReader<R>, uint| -> Result<T, IoError>) -> Result<T, IoError> {
+    f: |&mut DecoderReader<'a, R>, uint| -> IoResult<T>) -> IoResult<T> {
         let id = try!(self.read_uint());
         f(self, id)
     }
     fn read_enum_variant_arg<T>(&mut self, _: uint,
-    f: |&mut DecoderReader<R>| -> Result<T, IoError>) -> Result<T, IoError> {
+    f: |&mut DecoderReader<'a, R>| -> IoResult<T>) -> IoResult<T> {
         f(self)
     }
     fn read_enum_struct_variant<T>(&mut self, names: &[&str],
-    f: |&mut DecoderReader<R>, uint| -> Result<T, IoError>) -> Result<T, IoError> {
+    f: |&mut DecoderReader<'a, R>, uint| -> IoResult<T>) -> IoResult<T> {
         self.read_enum_variant(names, f)
     }
     fn read_enum_struct_variant_field<T>(&mut self, _: &str, f_idx: uint,
-    f: |&mut DecoderReader<R>| -> Result<T, IoError>) -> Result<T, IoError> {
+    f: |&mut DecoderReader<'a, R>| -> IoResult<T>) -> IoResult<T> {
         self.read_enum_variant_arg(f_idx, f)
     }
     fn read_struct<T>(&mut self, _: &str, _: uint,
-    f: |&mut DecoderReader<R>| -> Result<T, IoError>) -> Result<T, IoError> {
+    f: |&mut DecoderReader<'a, R>| -> IoResult<T>) -> IoResult<T> {
         f(self)
     }
     fn read_struct_field<T>(&mut self, _: &str, _: uint,
-    f: |&mut DecoderReader<R>| -> Result<T, IoError>) -> Result<T, IoError> {
+    f: |&mut DecoderReader<'a, R>| -> IoResult<T>) -> IoResult<T> {
         f(self)
     }
     fn read_tuple<T>(&mut self,
-    f: |&mut DecoderReader<R>, uint| -> Result<T, IoError>) ->
-    Result<T, IoError> {
+    f: |&mut DecoderReader<'a, R>, uint| -> IoResult<T>) ->
+    IoResult<T> {
         let len = try!(self.read_uint());
         f(self, len)
     }
     fn read_tuple_arg<T>(&mut self, _: uint,
-    f: |&mut DecoderReader<R>| -> Result<T, IoError>) -> Result<T, IoError> {
+    f: |&mut DecoderReader<'a, R>| -> IoResult<T>) -> IoResult<T> {
         f(self)
     }
     fn read_tuple_struct<T>(&mut self, _: &str,
-    f: |&mut DecoderReader<R>, uint| -> Result<T, IoError>) ->
-    Result<T, IoError> {
+    f: |&mut DecoderReader<'a, R>, uint| -> IoResult<T>) ->
+    IoResult<T> {
         self.read_tuple(f)
     }
     fn read_tuple_struct_arg<T>(&mut self, a_idx: uint,
-    f: |&mut DecoderReader<R>| -> Result<T, IoError>) -> Result<T, IoError> {
+    f: |&mut DecoderReader<'a, R>| -> IoResult<T>) -> IoResult<T> {
         self.read_tuple_arg(a_idx, f)
     }
     fn read_option<T>(&mut self,
-    f: |&mut DecoderReader<R>, bool| -> Result<T, IoError>) ->
-    Result<T, IoError> {
+    f: |&mut DecoderReader<'a, R>, bool| -> IoResult<T>) ->
+    IoResult<T> {
         match try!(self.reader.read_u8()) {
             1 => f(self, true),
             _ => f(self, false)
         }
     }
     fn read_seq<T>(&mut self,
-    f: |&mut DecoderReader<R>, uint| -> Result<T, IoError>) ->
-    Result<T, IoError> {
+    f: |&mut DecoderReader<'a, R>, uint| -> IoResult<T>) ->
+    IoResult<T> {
         let len = try!(self.read_uint());
         f(self, len)
     }
     fn read_seq_elt<T>(&mut self, _: uint,
-    f: |&mut DecoderReader<R>| -> Result<T, IoError>) -> Result<T, IoError> {
+    f: |&mut DecoderReader<'a, R>| -> IoResult<T>) -> IoResult<T> {
         f(self)
     }
     fn read_map<T>(&mut self,
-    f: |&mut DecoderReader<R>, uint| -> Result<T, IoError>) ->
-    Result<T, IoError> {
+    f: |&mut DecoderReader<'a, R>, uint| -> IoResult<T>) ->
+    IoResult<T> {
         let len = try!(self.read_uint());
         f(self, len)
     }
     fn read_map_elt_key<T>(&mut self, _: uint,
-    f: |&mut DecoderReader<R>| -> Result<T, IoError>) -> Result<T, IoError> {
+    f: |&mut DecoderReader<'a, R>| -> IoResult<T>) -> IoResult<T> {
         f(self)
     }
     fn read_map_elt_val<T>(&mut self, _: uint,
-    f: |&mut DecoderReader<R>| -> Result<T, IoError>) -> Result<T, IoError> {
+    f: |&mut DecoderReader<'a, R>| -> IoResult<T>) -> IoResult<T> {
         f(self)
     }
     fn error(&mut self, err: &str) -> IoError {

--- a/src/test.rs
+++ b/src/test.rs
@@ -16,9 +16,9 @@ use super::DecoderReader;
 use super::encode;
 use super::decode;
 
-fn the_same<
-            V: Encodable<EncoderWriter<MemWriter>, IoError>  +
-               Decodable<DecoderReader<MemReader>, IoError> +
+fn the_same<'a,
+            V: Encodable<EncoderWriter<'a, MemWriter>, IoError>  +
+               Decodable<DecoderReader<'a, MemReader>, IoError> +
                PartialEq + Show>(element: V) {
     assert!(element == decode(encode(&element).unwrap()).unwrap());
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,24 +1,21 @@
 use std::io::Writer;
 use std::io::IoError;
+use std::io::IoResult;
 use serialize::Encoder;
 
-type EwResult = Result<(), IoError>;
+type EwResult = IoResult<()>;
 
-pub struct EncoderWriter<W> {
-    writer: W
+pub struct EncoderWriter<'a, W: 'a> {
+    writer: &'a mut W
 }
 
-impl <W> EncoderWriter<W> {
-    pub fn new(w: W) -> EncoderWriter<W> {
+impl <'a, W: Writer> EncoderWriter<'a, W> {
+    pub fn new(w: &'a mut W) -> EncoderWriter<'a, W> {
         EncoderWriter{ writer: w }
     }
-
-    pub fn unwrap(self) -> W {
-        self.writer
-    }
 }
 
-impl <W: Writer> Encoder<IoError> for EncoderWriter<W> {
+impl<'a, W: Writer> Encoder<IoError> for EncoderWriter<'a, W> {
     fn emit_nil(&mut self) -> EwResult { Ok(()) }
     fn emit_uint(&mut self, v: uint) -> EwResult {
         self.writer.write_be_u64(v as u64)
@@ -67,84 +64,84 @@ impl <W: Writer> Encoder<IoError> for EncoderWriter<W> {
         self.writer.write_str(v)
     }
     fn emit_enum(&mut self, _: &str,
-    f: |&mut EncoderWriter<W>| -> EwResult) -> EwResult {
+    f: |&mut EncoderWriter<'a, W>| -> EwResult) -> EwResult {
         f(self)
     }
     fn emit_enum_variant(&mut self,
     _: &str, v_id: uint, _: uint,
-    f: |&mut EncoderWriter<W>| -> EwResult) -> EwResult {
+    f: |&mut EncoderWriter<'a, W>| -> EwResult) -> EwResult {
         try!(self.emit_uint(v_id));
         f(self)
     }
     fn emit_enum_variant_arg(&mut self, _: uint,
-    f: |&mut EncoderWriter<W>| -> EwResult) -> EwResult {
+    f: |&mut EncoderWriter<'a, W>| -> EwResult) -> EwResult {
         f(self)
     }
     fn emit_enum_struct_variant(&mut self, _: &str, _: uint,
-    _: uint, f: |&mut EncoderWriter<W>| -> EwResult) -> EwResult {
+    _: uint, f: |&mut EncoderWriter<'a, W>| -> EwResult) -> EwResult {
         f(self)
     }
     fn emit_enum_struct_variant_field(&mut self, _: &str,
-    _: uint, f: |&mut EncoderWriter<W>| -> EwResult) -> EwResult {
+    _: uint, f: |&mut EncoderWriter<'a, W>| -> EwResult) -> EwResult {
         f(self)
     }
     fn emit_struct(&mut self, _: &str, _: uint,
-    f: |&mut EncoderWriter<W>| -> EwResult) -> EwResult {
+    f: |&mut EncoderWriter<'a, W>| -> EwResult) -> EwResult {
         f(self)
     }
     fn emit_struct_field(&mut self, _: &str, _: uint,
-    f: |&mut EncoderWriter<W>| -> EwResult) -> EwResult {
+    f: |&mut EncoderWriter<'a, W>| -> EwResult) -> EwResult {
         f(self)
     }
     fn emit_tuple(&mut self, len: uint,
-    f: |&mut EncoderWriter<W>| -> EwResult) -> EwResult {
+    f: |&mut EncoderWriter<'a, W>| -> EwResult) -> EwResult {
         try!(self.emit_uint(len));
         f(self)
     }
     fn emit_tuple_arg(&mut self, _: uint,
-    f: |&mut EncoderWriter<W>| -> EwResult) -> EwResult {
+    f: |&mut EncoderWriter<'a, W>| -> EwResult) -> EwResult {
         f(self)
     }
     fn emit_tuple_struct(&mut self, _: &str, len: uint,
-    f: |&mut EncoderWriter<W>| -> EwResult) -> EwResult {
+    f: |&mut EncoderWriter<'a, W>| -> EwResult) -> EwResult {
         self.emit_tuple(len, f)
     }
     fn emit_tuple_struct_arg(&mut self, f_idx: uint,
-    f: |&mut EncoderWriter<W>| -> EwResult) -> EwResult {
+    f: |&mut EncoderWriter<'a, W>| -> EwResult) -> EwResult {
         self.emit_tuple_arg(f_idx, f)
     }
     fn emit_option(&mut self,
-    f: |&mut EncoderWriter<W>| -> EwResult) -> EwResult {
+    f: |&mut EncoderWriter<'a, W>| -> EwResult) -> EwResult {
         f(self)
     }
     fn emit_option_none(&mut self) -> EwResult {
         self.writer.write_u8(0)
     }
     fn emit_option_some(&mut self,
-    f: |&mut EncoderWriter<W>| -> EwResult) -> EwResult {
+    f: |&mut EncoderWriter<'a, W>| -> EwResult) -> EwResult {
         try!(self.writer.write_u8(1));
         f(self)
     }
     fn emit_seq(&mut self, len: uint,
-    f: |this: &mut EncoderWriter<W>| -> EwResult) -> EwResult {
+    f: |this: &mut EncoderWriter<'a, W>| -> EwResult) -> EwResult {
         try!(self.emit_uint(len));
         f(self)
     }
     fn emit_seq_elt(&mut self, _: uint,
-    f: |this: &mut EncoderWriter<W>| -> EwResult) -> EwResult {
+    f: |this: &mut EncoderWriter<'a, W>| -> EwResult) -> EwResult {
         f(self)
     }
     fn emit_map(&mut self, len: uint,
-    f: |&mut EncoderWriter<W>| -> EwResult) -> EwResult {
+    f: |&mut EncoderWriter<'a, W>| -> EwResult) -> EwResult {
         try!(self.emit_uint(len));
         f(self)
     }
     fn emit_map_elt_key(&mut self, _: uint,
-    f: |&mut EncoderWriter<W>| -> EwResult) -> EwResult {
+    f: |&mut EncoderWriter<'a, W>| -> EwResult) -> EwResult {
         f(self)
     }
     fn emit_map_elt_val(&mut self, _: uint,
-    f: |&mut EncoderWriter<W>| -> EwResult) -> EwResult {
+    f: |&mut EncoderWriter<'a, W>| -> EwResult) -> EwResult {
         f(self)
     }
 }


### PR DESCRIPTION
I borrowed the pattern used in the json encoder in the standard library. The code uses an unsafe block, but I guess it can be removed whenever https://github.com/rust-lang/rust/issues/14302 is resolved. All the tests pass at least :P
