### PR TITLE
Update to latest rust nightly.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ mod reader;
 pub fn encode<'a, T: Encodable<EncoderWriter<'a, MemWriter>, IoError>>(t: &T) ->IoResult<Vec<u8>> {
     let mut w = MemWriter::new();
     match encode_into(t, &mut w) {
-        Ok(()) => Ok(w.unwrap()),
+        Ok(()) => Ok(w.into_inner()),
         Err(e) => Err(e)
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -70,16 +70,16 @@ impl<'a, R: Reader+Buffer> Decoder<IoError> for DecoderReader<'a, R> {
         }
         Ok(String::from_utf8(vector).unwrap())
     }
-    fn read_enum<T, F>(&mut self, name: &str, f: F) -> IoResult<T> where
+    fn read_enum<T, F>(&mut self, _: &str, f: F) -> IoResult<T> where
         F: FnOnce(&mut DecoderReader<'a, R>) -> IoResult<T> {
             f(self)
         }
-    fn read_enum_variant<T, F>(&mut self, names: &[&str], f: F) -> IoResult<T> where
+    fn read_enum_variant<T, F>(&mut self, _: &[&str], f: F) -> IoResult<T> where
         F: FnOnce(&mut DecoderReader<'a, R>, uint) -> IoResult<T> {
             let id = try!(self.read_uint());
             f(self, id)
         }
-    fn read_enum_variant_arg<T, F>(&mut self, a_idx: uint, f: F) -> IoResult<T> where
+    fn read_enum_variant_arg<T, F>(&mut self, _: uint, f: F) -> IoResult<T> where
         F: FnOnce(&mut DecoderReader<'a, R>) -> IoResult<T> {
             f(self)
         }
@@ -95,27 +95,27 @@ impl<'a, R: Reader+Buffer> Decoder<IoError> for DecoderReader<'a, R> {
             F: FnOnce(&mut DecoderReader<'a, R>) -> IoResult<T> {
                 self.read_enum_variant_arg(f_idx, f)
             }
-    fn read_struct<T, F>(&mut self, s_name: &str, len: uint, f: F) -> IoResult<T> where
+    fn read_struct<T, F>(&mut self, _: &str, _: uint, f: F) -> IoResult<T> where
         F: FnOnce(&mut DecoderReader<'a, R>) -> IoResult<T> {
             f(self)
         }
     fn read_struct_field<T, F>(&mut self,
-                               f_name: &str,
-                               f_idx: uint,
+                               _: &str,
+                               _: uint,
                                f: F)
         -> IoResult<T> where
             F: FnOnce(&mut DecoderReader<'a, R>) -> IoResult<T> {
                 f(self)
             }
-    fn read_tuple<T, F>(&mut self, len: uint, f: F) -> IoResult<T> where
+    fn read_tuple<T, F>(&mut self, _: uint, f: F) -> IoResult<T> where
         F: FnOnce(&mut DecoderReader<'a, R>) -> IoResult<T> {
             f(self)
         }
-    fn read_tuple_arg<T, F>(&mut self, a_idx: uint, f: F) -> IoResult<T> where
+    fn read_tuple_arg<T, F>(&mut self, _: uint, f: F) -> IoResult<T> where
         F: FnOnce(&mut DecoderReader<'a, R>) -> IoResult<T> {
             f(self)
         }
-    fn read_tuple_struct<T, F>(&mut self, s_name: &str, len: uint, f: F) -> IoResult<T> where
+    fn read_tuple_struct<T, F>(&mut self, _: &str, len: uint, f: F) -> IoResult<T> where
         F: FnOnce(&mut DecoderReader<'a, R>) -> IoResult<T> {
             self.read_tuple(len, f)
         }
@@ -135,7 +135,7 @@ impl<'a, R: Reader+Buffer> Decoder<IoError> for DecoderReader<'a, R> {
             let len = try!(self.read_uint());
             f(self, len)
         }
-    fn read_seq_elt<T, F>(&mut self, idx: uint, f: F) -> IoResult<T> where
+    fn read_seq_elt<T, F>(&mut self, _: uint, f: F) -> IoResult<T> where
         F: FnOnce(&mut DecoderReader<'a, R>) -> IoResult<T> {
             f(self)
         }
@@ -144,11 +144,11 @@ impl<'a, R: Reader+Buffer> Decoder<IoError> for DecoderReader<'a, R> {
             let len = try!(self.read_uint());
             f(self, len)
         }
-    fn read_map_elt_key<T, F>(&mut self, idx: uint, f: F) -> IoResult<T> where
+    fn read_map_elt_key<T, F>(&mut self, _: uint, f: F) -> IoResult<T> where
         F: FnOnce(&mut DecoderReader<'a, R>) -> IoResult<T> {
             f(self)
         }
-    fn read_map_elt_val<T, F>(&mut self, idx: uint, f: F) -> IoResult<T> where
+    fn read_map_elt_val<T, F>(&mut self, _: uint, f: F) -> IoResult<T> where
         F: FnOnce(&mut DecoderReader<'a, R>) -> IoResult<T> {
             f(self)
         }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -61,53 +61,53 @@ impl<'a, W: Writer> Encoder<IoError> for EncoderWriter<'a, W> {
         try!(self.emit_uint(v.len()));
         self.writer.write_str(v)
     }
-    fn emit_enum<F>(&mut self, name: &str, f: F) -> EwResult where
+    fn emit_enum<F>(&mut self, __: &str, f: F) -> EwResult where
         F: FnOnce(&mut EncoderWriter<'a, W>) -> EwResult {
             f(self)
         }
-    fn emit_enum_variant<F>(&mut self, v_name: &str,
+    fn emit_enum_variant<F>(&mut self, _: &str,
                             v_id: uint,
-                            len: uint,
+                            _: uint,
                             f: F) -> EwResult where
         F: FnOnce(&mut EncoderWriter<'a, W>) -> EwResult {
             try!(self.emit_uint(v_id));
             f(self)
         }
-    fn emit_enum_variant_arg<F>(&mut self, a_idx: uint, f: F) -> EwResult where
+    fn emit_enum_variant_arg<F>(&mut self, _: uint, f: F) -> EwResult where
         F: FnOnce(&mut EncoderWriter<'a, W>) -> EwResult {
             f(self)
         }
-    fn emit_enum_struct_variant<F>(&mut self, v_name: &str,
-                                   v_id: uint,
-                                   len: uint,
+    fn emit_enum_struct_variant<F>(&mut self, _: &str,
+                                   _: uint,
+                                   _: uint,
                                    f: F) -> EwResult where
         F: FnOnce(&mut EncoderWriter<'a, W>) -> EwResult {
             f(self)
         }
     fn emit_enum_struct_variant_field<F>(&mut self,
-                                         f_name: &str,
-                                         f_idx: uint,
+                                         _: &str,
+                                         _: uint,
                                          f: F) -> EwResult where
         F: FnOnce(&mut EncoderWriter<'a, W>) -> EwResult {
             f(self)
         }
-    fn emit_struct<F>(&mut self, name: &str, len: uint, f: F) -> EwResult where
+    fn emit_struct<F>(&mut self, _: &str, _: uint, f: F) -> EwResult where
         F: FnOnce(&mut EncoderWriter<'a, W>) -> EwResult {
             f(self)
         }
-    fn emit_struct_field<F>(&mut self, f_name: &str, f_idx: uint, f: F) -> EwResult where
+    fn emit_struct_field<F>(&mut self, _: &str, _: uint, f: F) -> EwResult where
         F: FnOnce(&mut EncoderWriter<'a, W>) -> EwResult {
             f(self)
         }
-    fn emit_tuple<F>(&mut self, len: uint, f: F) -> EwResult where
+    fn emit_tuple<F>(&mut self, _: uint, f: F) -> EwResult where
         F: FnOnce(&mut EncoderWriter<'a, W>) -> EwResult {
             f(self)
         }
-    fn emit_tuple_arg<F>(&mut self, idx: uint, f: F) -> EwResult where
+    fn emit_tuple_arg<F>(&mut self, _: uint, f: F) -> EwResult where
         F: FnOnce(&mut EncoderWriter<'a, W>) -> EwResult {
             f(self)
         }
-    fn emit_tuple_struct<F>(&mut self, name: &str, len: uint, f: F) -> EwResult where
+    fn emit_tuple_struct<F>(&mut self, _: &str, len: uint, f: F) -> EwResult where
         F: FnOnce(&mut EncoderWriter<'a, W>) -> EwResult {
             self.emit_tuple(len, f)
         }
@@ -132,7 +132,7 @@ impl<'a, W: Writer> Encoder<IoError> for EncoderWriter<'a, W> {
             try!(self.emit_uint(len));
             f(self)
         }
-    fn emit_seq_elt<F>(&mut self, idx: uint, f: F) -> EwResult where
+    fn emit_seq_elt<F>(&mut self, _: uint, f: F) -> EwResult where
         F: FnOnce(&mut EncoderWriter<'a, W>) -> EwResult {
             f(self)
         }
@@ -141,11 +141,11 @@ impl<'a, W: Writer> Encoder<IoError> for EncoderWriter<'a, W> {
             try!(self.emit_uint(len));
             f(self)
         }
-    fn emit_map_elt_key<F>(&mut self, idx: uint, mut f: F) -> EwResult where
+    fn emit_map_elt_key<F>(&mut self, _: uint, mut f: F) -> EwResult where
         F: FnMut(&mut EncoderWriter<'a, W>) -> EwResult {
             f(self)
         }
-    fn emit_map_elt_val<F>(&mut self, idx: uint, f: F) -> EwResult where
+    fn emit_map_elt_val<F>(&mut self, _: uint, f: F) -> EwResult where
         F: FnOnce(&mut EncoderWriter<'a, W>) -> EwResult {
             f(self)
         }


### PR DESCRIPTION
- rustc 0.13.0-nightly (126db549b 2014-12-15 00:07:35 +0000)

The changeset is fairly large since the trait methods are now using unboxed closures, everything looks good on `cargo test` though.
