### PR TITLE
Add dependencies for Cargo.toml in the example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,8 +27,22 @@ library.
 
 ## Example
 
+#### **`Cargo.toml`**
+
+```toml
+[dependencies]
+bincode = "1.2"
+serde =  { version = "1.0", features = ["derive"] }
+```
+
+#### **`main.rs`**
+
 ```rust
-use serde::{Serialize, Deserialize};
+#[macro_use]
+extern crate serde_derive;
+extern crate bincode;
+
+use bincode::{deserialize, serialize};
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 struct Entity {
@@ -42,12 +56,12 @@ struct World(Vec<Entity>);
 fn main() {
     let world = World(vec![Entity { x: 0.0, y: 4.0 }, Entity { x: 10.0, y: 20.5 }]);
 
-    let encoded: Vec<u8> = bincode::serialize(&world).unwrap();
+    let encoded: Vec<u8> = serialize(&world).unwrap();
 
-    // 8 bytes for the length of the vector, 4 bytes per float.
+    // 8 bytes for the length of the vector (usize), 4 bytes per float.
     assert_eq!(encoded.len(), 8 + 4 * 4);
 
-    let decoded: World = bincode::deserialize(&encoded[..]).unwrap();
+    let decoded: World = deserialize(&encoded[..]).unwrap();
 
     assert_eq!(world, decoded);
 }


### PR DESCRIPTION
By default the `Derive` macro of Serde isn't available. This cause the example
in the Readme to fail. This commit give one possible way to solve the issue.

This should solve #251 