### PR TITLE
Add null terminated string option

### DIFF
--- a/src/config/str.rs
+++ b/src/config/str.rs
@@ -1,19 +1,20 @@
 use std::io::Write;
 
-use crate::ser::SizeChecker;
-
-use super::IntEncoding;
-use super::Options;
-use error::Result;
+use super::{BincodeRead, IntEncoding, Options};
+use crate::error::{ErrorKind, Result};
 use serde::Serializer;
 
 pub trait StrEncoding {
     fn serialize_str<W: Write, O: Options>(
-        ser: &mut ::ser::Serializer<W, O>,
+        ser: &mut crate::ser::Serializer<W, O>,
         v: &str,
     ) -> Result<()>;
 
     fn get_len<O: Options>(s: &str) -> u64;
+
+    fn deserialize_str<'de, R: BincodeRead<'de>, O: Options>(
+        de: &mut crate::de::Deserializer<R, O>,
+    ) -> Result<String>;
 }
 
 /// Encode strings the same way as vectors,
@@ -35,6 +36,13 @@ impl StrEncoding for LenStrEncoding {
     fn get_len<O: Options>(s: &str) -> u64 {
         O::IntEncoding::len_size(s.len()) + s.len() as u64
     }
+
+    fn deserialize_str<'de, R: BincodeRead<'de>, O: Options>(
+        de: &mut crate::Deserializer<R, O>,
+    ) -> Result<String> {
+        let vec = de.read_vec()?;
+        String::from_utf8(vec).map_err(|e| ErrorKind::InvalidUtf8Encoding(e.utf8_error()).into())
+    }
 }
 
 impl StrEncoding for NullTerminatedStrEncoding {
@@ -49,5 +57,18 @@ impl StrEncoding for NullTerminatedStrEncoding {
 
     fn get_len<O: Options>(s: &str) -> u64 {
         s.len() as u64 + "\0".len() as u64
+    }
+
+    fn deserialize_str<'de, R: BincodeRead<'de>, O: Options>(
+        de: &mut crate::Deserializer<R, O>,
+    ) -> Result<String> {
+        let vec = std::iter::repeat(0)
+            .map(|_| de.deserialize_byte())
+            .take_while(|r| match r {
+                Ok(r) => *r != 0x0,
+                Err(_) => false,
+            })
+            .collect::<Result<Vec<_>>>()?;
+        String::from_utf8(vec).map_err(|e| ErrorKind::InvalidUtf8Encoding(e.utf8_error()).into())
     }
 }

--- a/src/config/str.rs
+++ b/src/config/str.rs
@@ -1,0 +1,41 @@
+use std::io::Write;
+
+use super::IntEncoding;
+use super::Options;
+use error::Result;
+use serde::Serializer;
+
+pub trait StrEncoding {
+    fn serialize_str<W: Write, O: Options>(
+        ser: &mut ::ser::Serializer<W, O>,
+        v: &str,
+    ) -> Result<()>;
+}
+
+/// Encode strings the same way as vectors,
+/// as the length followed by the data.
+pub struct LenStrEncoding;
+
+/// Encode strings c-style, with the contents
+/// followed by a null byte.
+pub struct NullTerminatedStrEncoding;
+
+impl StrEncoding for LenStrEncoding {
+    fn serialize_str<W: Write, O: Options>(
+        ser: &mut crate::Serializer<W, O>,
+        v: &str,
+    ) -> Result<()> {
+        ser.serialize_bytes(v.as_bytes()).map_err(Into::into)
+    }
+}
+
+impl StrEncoding for NullTerminatedStrEncoding {
+    fn serialize_str<W: Write, O: Options>(
+        ser: &mut crate::Serializer<W, O>,
+        v: &str,
+    ) -> Result<()> {
+        ser.serialize_raw(v.as_bytes())
+            .and_then(|_| ser.serialize_byte(0x0))
+            .map_err(Into::into)
+    }
+}

--- a/src/config/str.rs
+++ b/src/config/str.rs
@@ -50,7 +50,11 @@ impl StrEncoding for NullTerminatedStrEncoding {
         ser: &mut crate::Serializer<W, O>,
         v: &str,
     ) -> Result<()> {
-        ser.serialize_raw(v.as_bytes())
+        let bytes = v.as_bytes();
+        if bytes.iter().any(|&b| b == 0) {
+            panic!("Attempted to serialize string with null byte")
+        };
+        ser.serialize_raw(bytes)
             .and_then(|_| ser.serialize_byte(0x0))
             .map_err(Into::into)
     }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2,7 +2,7 @@ use crate::config::{BincodeByteOrder, Options};
 use std::io::Read;
 
 use self::read::{BincodeRead, IoReader, SliceReader};
-use crate::config::{IntEncoding, SizeLimit};
+use crate::config::{IntEncoding, SizeLimit, StrEncoding};
 use crate::{Error, ErrorKind, Result};
 use byteorder::ReadBytesExt;
 use serde::de::Error as DeError;
@@ -89,15 +89,14 @@ impl<'de, R: BincodeRead<'de>, O: Options> Deserializer<R, O> {
         self.read_bytes(size_of::<T>() as u64)
     }
 
-    fn read_vec(&mut self) -> Result<Vec<u8>> {
+    pub(crate) fn read_vec(&mut self) -> Result<Vec<u8>> {
         let len = O::IntEncoding::deserialize_len(self)?;
         self.read_bytes(len as u64)?;
         self.reader.get_byte_buffer(len)
     }
 
     fn read_string(&mut self) -> Result<String> {
-        let vec = self.read_vec()?;
-        String::from_utf8(vec).map_err(|e| ErrorKind::InvalidUtf8Encoding(e.utf8_error()).into())
+        O::StrEncoding::deserialize_str(self)
     }
 }
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -3,7 +3,7 @@ use std::u32;
 
 use byteorder::WriteBytesExt;
 
-use super::config::{IntEncoding, SizeLimit};
+use super::config::{IntEncoding, SizeLimit, StrEncoding};
 use super::{Error, ErrorKind, Result};
 use crate::config::{BincodeByteOrder, Options};
 use std::mem::size_of;
@@ -37,6 +37,10 @@ impl<W: Write, O: Options> Serializer<W, O> {
             writer: w,
             _options: options,
         }
+    }
+
+    pub(crate) fn serialize_raw(&mut self, v: &[u8]) -> Result<()> {
+        self.writer.write_all(v).map_err(Into::into)
     }
 
     pub(crate) fn serialize_byte(&mut self, v: u8) -> Result<()> {
@@ -117,8 +121,7 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
     }
 
     fn serialize_str(self, v: &str) -> Result<()> {
-        O::IntEncoding::serialize_len(self, v.len())?;
-        self.writer.write_all(v.as_bytes()).map_err(Into::into)
+        O::StrEncoding::serialize_str(self, v)
     }
 
     fn serialize_char(self, c: char) -> Result<()> {

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -315,8 +315,7 @@ impl<'a, O: Options> serde::Serializer for &'a mut SizeChecker<O> {
     }
 
     fn serialize_str(self, v: &str) -> Result<()> {
-        self.add_len(v.len())?;
-        self.add_raw(v.len() as u64)
+        self.add_raw(O::StrEncoding::get_len::<O>(v))
     }
 
     fn serialize_char(self, c: char) -> Result<()> {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -59,6 +59,15 @@ where
     }
 
     all_integer_encodings!(element, DefaultOptions::new());
+
+    macro_rules! all_string_terminations {
+        ($element:expr, $options:expr) => {
+            all_integer_encodings!($element, $options.with_len_str_encoding());
+            all_integer_encodings!($element, $options.with_null_terminated_str_encoding());
+        };
+    }
+
+    all_string_terminations!(element, DefaultOptions::new());
 }
 
 #[test]


### PR DESCRIPTION
Hello!

I am working with a protocol that is 99% compatible with the data structures I already use, bar one thing: it uses c-style strings. I know that bincode is technically its own protocol but if we were to support different string formats it would save me 100 lines of custom code...

...So here's 140 lines of custom code that adds a flag similar to the varint flag that allows the user to select between 'vec-style' encoding and 'c-style' encoding. I have marked it as a draft because I wanted to make sure you were open to merging something like this before I finished it.

Thanks! :christmas_tree: 