### PR TITLE
Edit version badge link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 ![CI](https://github.com/bincode-org/bincode/workflows/CI/badge.svg)
 [![](https://meritbadge.herokuapp.com/bincode)](https://crates.io/crates/bincode)
 [![](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![](https://img.shields.io/badge/bincode-rustc_1.41.1+-lightgray.svg)](https://blog.rust-lang.org/2020/06/18/Rust.1.44.1.html)
+[![](https://img.shields.io/badge/bincode-rustc_1.41.1+-lightgray.svg)](https://blog.rust-lang.org/2020/02/27/Rust-1.41.1.html)
 
 A compact encoder / decoder pair that uses a binary zero-fluff encoding scheme.
 The size of the encoded object will be the same or smaller than the size that


### PR DESCRIPTION
The Readme states that the MSRV is 1.41.1 but this badge linked to 1.44.1 instead. Was that just a mixup?