### PR TITLE
Unignore doctests where possible

### DIFF
--- a/src/config/int.rs
+++ b/src/config/int.rs
@@ -147,7 +147,7 @@ pub struct FixintEncoding;
 /// fn zigzag(v: Signed) -> Unsigned {
 ///     match v {
 ///         0 => 0,
-///         v if v < 0 => |v| * 2 - 1
+///         v if v < 0 => |v| * 2 - 1,
 ///         v if v > 0 => v * 2
 ///     }
 /// }
@@ -155,7 +155,8 @@ pub struct FixintEncoding;
 ///
 /// And works such that:
 ///
-/// ```ignore
+/// ```no_run
+/// # let zigzag = |_| 0;
 /// assert_eq!(zigzag(0), 0);
 /// assert_eq!(zigzag(-1), 1);
 /// assert_eq!(zigzag(1), 2);

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -19,10 +19,12 @@ pub mod read;
 /// The ByteOrder that is chosen will impact the endianness that
 /// is used to read integers out of the reader.
 ///
-/// ```ignore
-/// let d = Deserializer::new(&mut some_reader, SizeLimit::new());
-/// serde::Deserialize::deserialize(&mut deserializer);
-/// let bytes_read = d.bytes_read();
+/// ```
+/// # use bincode::Deserializer;
+/// let input = [3];
+/// let mut deserializer = Deserializer::from_slice(&input, bincode::options());
+/// let value: u32 = serde::Deserialize::deserialize(&mut deserializer).unwrap();
+/// assert_eq!(value, 3);
 /// ```
 pub struct Deserializer<R, O: Options> {
     pub(crate) reader: R,

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -15,6 +15,16 @@ use std::mem::size_of;
 ///
 /// This struct should not be used often.
 /// For most cases, prefer the `encode_into` function.
+///
+/// ```
+/// # use bincode::Serializer;
+/// # use serde::ser::Serialize;
+/// let mut output: Vec<u8> = vec!();
+/// let mut serializer = Serializer::new(&mut output, bincode::options());
+/// let value = 3u32;
+/// value.serialize(&mut serializer).unwrap();
+/// assert_eq!(output, [3]);
+/// ```
 pub struct Serializer<W, O: Options> {
     writer: W,
     _options: O,


### PR DESCRIPTION
closes https://github.com/bincode-org/bincode/issues/363

Possibly we would be better off just deleting the examples from Serializer and Deserializer?
I dont mind either way.

I left the zigzag example as ignore because its a pseudocode demonstration and getting it compiling would obscure the intent.