### PR TITLE
Exposes in-place deserialization from buffers using SliceReader

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -208,6 +208,17 @@ pub trait Options: InternalOptions + Sized {
         crate::internal::deserialize_in_place(reader, self, place)
     }
 
+    /// TODO: document
+    #[doc(hidden)]
+    #[inline(always)]
+    fn deserialize_in_place_buffer<'a, T: serde::de::Deserialize<'a>>(
+        self,
+        bytes: &'a [u8],
+        place: &mut T
+    ) -> Result<()> {
+        crate::internal::deserialize_in_place_buffer(bytes, self, place)
+    }
+
     /// Deserializes a slice of bytes with state `seed` using this configuration.
     #[inline(always)]
     fn deserialize_seed<'a, T: serde::de::DeserializeSeed<'a>>(

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -97,6 +97,16 @@ where
     serde::Deserialize::deserialize_in_place(&mut deserializer, place)
 }
 
+pub(crate) fn deserialize_in_place_buffer<'a, T, O>(bytes: &'a [u8], options: O, place: &mut T) -> Result<()>
+where
+    T: serde::de::Deserialize<'a>,
+    O: InternalOptions,
+{
+    let reader = crate::de::read::SliceReader::new(bytes);
+    let mut deserializer = crate::de::Deserializer::<_, _>::with_bincode_read(reader, options);
+    serde::Deserialize::deserialize_in_place(&mut deserializer, place)
+}
+
 pub(crate) fn deserialize<'a, T, O>(bytes: &'a [u8], options: O) -> Result<T>
 where
     T: serde::de::Deserialize<'a>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,17 @@ where
     DefaultOptions::new().deserialize_in_place(reader, place)
 }
 
+/// Only use this if you know what you're doing.
+///
+/// This is part of the public API.
+#[doc(hidden)]
+pub fn deserialize_in_place_buffer<'a, T>(bytes: &'a [u8], place: &mut T) -> Result<()>
+where
+    T: serde::de::Deserialize<'a>,
+{
+    DefaultOptions::new().deserialize_in_place_buffer(bytes, place)
+}
+
 /// Deserializes a slice of bytes into an instance of `T` using the default configuration.
 pub fn deserialize<'a, T>(bytes: &'a [u8]) -> Result<T>
 where


### PR DESCRIPTION
Updating values in place is rare, but it is safe to do from a slice.
Adding a function `deserialize_in_place_buffer` allows users to do this
in-place update without having to vendor SliceReader.

Pretty much my situation. I have a mmap-based database from which I want to pull updates into existing structs.

The alternatives are allowing construction of a `SliceReader` from an arbitrary byteslice (i.e. making `SliceReader::new()` `pub` instead of `pub(crate)`) and vendoring the entire code of `SliceReader` verbatim, the latter being what I'm trying to avoid.

EDIT: I just now realized that I could also just create a `bincode::de::Deserializer` and use that with `serde::Deserialize::deserialize_in_place`. However that works less well with my current code structure, so if you feel like this PR doesn't clutter your export table unduly I would still prefer to do it this way. 