### PR TITLE
Fix typo of version number in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -110,4 +110,4 @@ maximum size limit. Malicious inputs will fail upon deserialization.
 
 ### What is Bincode's MSRV (minimum supported Rust version)?
 
-Bincode 2.0 maintains support for Rust 1.41.1. Any changes to this are considered a breaking change for semver purposes.
+Bincode 1.0 maintains support for Rust 1.41.1. Any changes to this are considered a breaking change for semver purposes.


### PR DESCRIPTION
I'm assuming this is a typo since I don't see a Bincode 2.0 release.  If I've misunderstood then please feel free to close this.

Thanks!