### PR TITLE
Replace test-all-features with a manual CI matrix

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,6 @@
     "push": {
       "branches": [
         "trunk",
-        "bincode2/ci_matrix", # Temporary, don't merge this
         "v*.x"
       ]
     },

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@
     "push": {
       "branches": [
         "trunk",
-        "feature/deserde*", # Temporary while we work on deserde
+        "bincode2/ci_matrix", # Temporary, don't merge this
         "v*.x"
       ]
     },
@@ -50,17 +50,15 @@
             "command": "check"
           },
           "name": "Run `cargo check`"
+        },
+        {
+          "uses": "actions-rs/cargo@v1",
+          "with": {
+            "command": "check",
+            "args": "--examples"
+          },
+          "name": "Check examples"
         }
-        # ,
-        # {
-        #   "uses": "actions-rs/cargo@v1",
-        #   "with": {
-        #     "command": "check",
-        #     "args": "--examples"
-        #   },
-        #   "name": "Check examples",
-        #   "if": "matrix.rust != '1.41.0'"
-        # }
       ]
     },
     "test": {
@@ -73,6 +71,15 @@
             "beta",
             "nightly"
             # "1.55.0" TODO: Pick latest stable version when we release 2.0
+          ],
+          "features": [
+            "",
+            "alloc",
+            "alloc,derive",
+            "std",
+            "std,derive",
+            "serde",
+            "serde,derive"
           ]
         }
       },
@@ -91,15 +98,12 @@
           "name": "Install Rust ${{ matrix.rust }}"
         },
         {
-          "uses": "actions-rs/install@v0.1",
-          "with": {
-            "crate": "cargo-all-features",
-            "version": "1.6.0"
-          },
-          "name": "Install cargo-all-features"
-        },
-        {
-          "run": "cargo test-all-features",
+          "run": "if [ -z \"${{ matrix.features }}\" ]\n
+then\n
+  cargo test --no-default-features\n
+else\n
+  cargo test --no-default-features --features ${{ matrix.features }}\n
+fi",
           "name": "Run `cargo test` on all features",
           "env": {
             "RUSTFLAGS": "-D warnings"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,8 @@
         {
           "uses": "actions-rs/cargo@v1",
           "with": {
-            "command": "check"
+            "command": "check",
+            "args": "--all-features"
           },
           "name": "Run `cargo check`"
         },
@@ -68,8 +69,6 @@
         "matrix": {
           "rust": [
             "stable",
-            "beta",
-            "nightly"
             # "1.55.0" TODO: Pick latest stable version when we release 2.0
           ],
           "features": [


### PR DESCRIPTION
Because the `cargo test-all-features` run was taking almost 10 minutes, I've replaced it by a manual build matrix.

Additionally I've moved the beta and nightly rust versions to the `cargo check`. We probably won't need to run tests on those channels (if we do, we can change it back in the future).

