### PR TITLE
Generate qualified Result type in derive

### DIFF
--- a/derive/src/derive_enum.rs
+++ b/derive/src/derive_enum.rs
@@ -97,7 +97,7 @@ impl DeriveEnum {
                 .generate_fn("borrow_decode")
                 .with_generic("D", ["bincode::de::BorrowDecoder<'__de>"])
                 .with_arg("mut decoder", "D")
-                .with_return_type("Result<Self, bincode::error::DecodeError>")
+                .with_return_type("core::result::Result<Self, bincode::error::DecodeError>")
                 .body(|fn_builder| {
                     fn_builder
                         .push_parsed("let variant_index = <u32 as bincode::de::Decode>::decode(&mut decoder)?;").unwrap();
@@ -147,7 +147,7 @@ impl DeriveEnum {
                 .generate_fn("decode")
                 .with_generic("D", ["bincode::de::Decoder"])
                 .with_arg("mut decoder", "D")
-                .with_return_type("Result<Self, bincode::error::DecodeError>")
+                .with_return_type("core::result::Result<Self, bincode::error::DecodeError>")
                 .body(|fn_builder| {
                     fn_builder
                         .push_parsed("let variant_index = <u32 as bincode::de::Decode>::decode(&mut decoder)?;").unwrap();

--- a/derive/src/derive_struct.rs
+++ b/derive/src/derive_struct.rs
@@ -18,7 +18,7 @@ impl DeriveStruct {
             .with_generic("E", ["bincode::enc::Encoder"])
             .with_self_arg(crate::generate::FnSelfArg::RefSelf)
             .with_arg("mut encoder", "E")
-            .with_return_type("Result<(), bincode::error::EncodeError>")
+            .with_return_type("core::result::Result<(), bincode::error::EncodeError>")
             .body(|fn_body| {
                 for field in fields.names() {
                     fn_body
@@ -47,7 +47,7 @@ impl DeriveStruct {
                 .generate_fn("borrow_decode")
                 .with_generic("D", ["bincode::de::BorrowDecoder<'__de>"])
                 .with_arg("mut decoder", "D")
-                .with_return_type("Result<Self, bincode::error::DecodeError>")
+                .with_return_type("core::result::Result<Self, bincode::error::DecodeError>")
                 .body(|fn_body| {
                     // Ok(Self {
                     fn_body.ident_str("Ok");
@@ -77,7 +77,7 @@ impl DeriveStruct {
                 .generate_fn("decode")
                 .with_generic("D", ["bincode::de::Decoder"])
                 .with_arg("mut decoder", "D")
-                .with_return_type("Result<Self, bincode::error::DecodeError>")
+                .with_return_type("core::result::Result<Self, bincode::error::DecodeError>")
                 .body(|fn_body| {
                     // Ok(Self {
                     fn_body.ident_str("Ok");


### PR DESCRIPTION
This prevents problems with generated code when there's an alias for a crate-specific `Result` type, i.e. `type Result<T> = std::result::Result<T, MyError>`.