### PR TITLE
split off BorrowDecode from Decode in bincode_derive

### DIFF
--- a/derive/src/derive_enum.rs
+++ b/derive/src/derive_enum.rs
@@ -168,7 +168,7 @@ impl DeriveEnum {
         let enum_name = generator.target_name().to_string();
 
         generator
-            .impl_for("bincode::de::Decode")
+            .impl_for("bincode::Decode")
             .unwrap()
             .generate_fn("decode")
             .with_generic("D", ["bincode::de::Decoder"])
@@ -177,7 +177,7 @@ impl DeriveEnum {
             .body(|fn_builder| {
                 fn_builder
                     .push_parsed(
-                        "let variant_index = <u32 as bincode::de::Decode>::decode(&mut decoder)?;",
+                        "let variant_index = <u32 as bincode::Decode>::decode(&mut decoder)?;",
                     )
                     .unwrap();
                 fn_builder.push_parsed("match variant_index").unwrap();
@@ -210,7 +210,7 @@ impl DeriveEnum {
                                     }
                                     variant_body.punct(':');
                                     variant_body
-                                        .push_parsed("bincode::de::Decode::decode(&mut decoder)?,")
+                                        .push_parsed("bincode::Decode::decode(&mut decoder)?,")
                                         .unwrap();
                                 }
                             });
@@ -239,7 +239,7 @@ impl DeriveEnum {
             .with_return_type("core::result::Result<Self, bincode::error::DecodeError>")
             .body(|fn_builder| {
                 fn_builder
-                    .push_parsed("let variant_index = <u32 as bincode::de::Decode>::decode(&mut decoder)?;").unwrap();
+                    .push_parsed("let variant_index = <u32 as bincode::Decode>::decode(&mut decoder)?;").unwrap();
                 fn_builder.push_parsed("match variant_index").unwrap();
                 fn_builder.group(Delimiter::Brace, |variant_case| {
                     for (mut variant_index, variant) in self.iter_fields() {

--- a/derive/src/derive_enum.rs
+++ b/derive/src/derive_enum.rs
@@ -91,7 +91,7 @@ impl DeriveEnum {
         let enum_name = generator.target_name().to_string();
 
         // enum has no lifetimes, implement Decode
-        generator.impl_for("bincode::de::Decode")
+        generator.impl_for("bincode::Decode")
         .unwrap()
             .generate_fn("decode")
             .with_generic("D", ["bincode::de::Decoder"])
@@ -99,7 +99,7 @@ impl DeriveEnum {
             .with_return_type("core::result::Result<Self, bincode::error::DecodeError>")
             .body(|fn_builder| {
                 fn_builder
-                    .push_parsed("let variant_index = <u32 as bincode::de::Decode>::decode(&mut decoder)?;").unwrap();
+                    .push_parsed("let variant_index = <u32 as bincode::Decode>::decode(&mut decoder)?;").unwrap();
                 fn_builder.push_parsed("match variant_index").unwrap();
                 fn_builder.group(Delimiter::Brace, |variant_case| {
                 for (idx, variant) in variants.iter().enumerate() {
@@ -124,7 +124,7 @@ impl DeriveEnum {
                                     variant_body.ident(field.unwrap_ident().clone());
                                 }
                                 variant_body.punct(':');
-                                variant_body.push_parsed("bincode::de::Decode::decode(&mut decoder)?,").unwrap();
+                                variant_body.push_parsed("bincode::Decode::decode(&mut decoder)?,").unwrap();
                             }
                         });
                     });
@@ -156,7 +156,7 @@ impl DeriveEnum {
             .with_return_type("core::result::Result<Self, bincode::error::DecodeError>")
             .body(|fn_builder| {
                 fn_builder
-                    .push_parsed("let variant_index = <u32 as bincode::de::Decode>::decode(&mut decoder)?;").unwrap();
+                    .push_parsed("let variant_index = <u32 as bincode::Decode>::decode(&mut decoder)?;").unwrap();
                 fn_builder.push_parsed("match variant_index").unwrap();
                 fn_builder.group(Delimiter::Brace, |variant_case| {
                 for (idx, variant) in variants.iter().enumerate() {

--- a/derive/src/derive_enum.rs
+++ b/derive/src/derive_enum.rs
@@ -90,7 +90,6 @@ impl DeriveEnum {
         let DeriveEnum { variants } = self;
         let enum_name = generator.target_name().to_string();
 
-        // enum has no lifetimes, implement Decode
         generator.impl_for("bincode::Decode")
         .unwrap()
             .generate_fn("decode")

--- a/derive/src/derive_struct.rs
+++ b/derive/src/derive_struct.rs
@@ -42,7 +42,7 @@ impl DeriveStruct {
         // struct has no lifetimes, implement Decode
 
         generator
-            .impl_for("bincode::de::Decode")
+            .impl_for("bincode::Decode")
             .unwrap()
             .generate_fn("decode")
             .with_generic("D", ["bincode::de::Decoder"])
@@ -56,14 +56,14 @@ impl DeriveStruct {
                     ok_group.group(Delimiter::Brace, |struct_body| {
                         // Fields
                         // {
-                        //      a: bincode::de::Decode::decode(&mut decoder)?,
-                        //      b: bincode::de::Decode::decode(&mut decoder)?,
+                        //      a: bincode::Decode::decode(&mut decoder)?,
+                        //      b: bincode::Decode::decode(&mut decoder)?,
                         //      ...
                         // }
                         for field in fields.names() {
                             struct_body
                                 .push_parsed(format!(
-                                    "{}: bincode::de::Decode::decode(&mut decoder)?,",
+                                    "{}: bincode::Decode::decode(&mut decoder)?,",
                                     field.to_string()
                                 ))
                                 .unwrap();

--- a/derive/src/derive_struct.rs
+++ b/derive/src/derive_struct.rs
@@ -39,8 +39,6 @@ impl DeriveStruct {
         // Remember to keep this mostly in sync with generate_borrow_decode
         let DeriveStruct { fields } = self;
 
-        // struct has no lifetimes, implement Decode
-
         generator
             .impl_for("bincode::Decode")
             .unwrap()

--- a/derive/src/derive_struct.rs
+++ b/derive/src/derive_struct.rs
@@ -36,74 +36,76 @@ impl DeriveStruct {
     }
 
     pub fn generate_decode(self, generator: &mut Generator) -> Result<()> {
+        // Remember to keep this mostly in sync with generate_borrow_decode
         let DeriveStruct { fields } = self;
 
-        if generator.has_lifetimes() {
-            // struct has a lifetime, implement BorrowDecode
+        // struct has no lifetimes, implement Decode
 
-            generator
-                .impl_for_with_de_lifetime("bincode::de::BorrowDecode<'__de>")
-                .unwrap()
-                .generate_fn("borrow_decode")
-                .with_generic("D", ["bincode::de::BorrowDecoder<'__de>"])
-                .with_arg("mut decoder", "D")
-                .with_return_type("core::result::Result<Self, bincode::error::DecodeError>")
-                .body(|fn_body| {
-                    // Ok(Self {
-                    fn_body.ident_str("Ok");
-                    fn_body.group(Delimiter::Parenthesis, |ok_group| {
-                        ok_group.ident_str("Self");
-                        ok_group.group(Delimiter::Brace, |struct_body| {
-                            for field in fields.names() {
-                                struct_body
-                                    .push_parsed(format!(
+        generator
+            .impl_for("bincode::de::Decode")
+            .unwrap()
+            .generate_fn("decode")
+            .with_generic("D", ["bincode::de::Decoder"])
+            .with_arg("mut decoder", "D")
+            .with_return_type("core::result::Result<Self, bincode::error::DecodeError>")
+            .body(|fn_body| {
+                // Ok(Self {
+                fn_body.ident_str("Ok");
+                fn_body.group(Delimiter::Parenthesis, |ok_group| {
+                    ok_group.ident_str("Self");
+                    ok_group.group(Delimiter::Brace, |struct_body| {
+                        // Fields
+                        // {
+                        //      a: bincode::de::Decode::decode(&mut decoder)?,
+                        //      b: bincode::de::Decode::decode(&mut decoder)?,
+                        //      ...
+                        // }
+                        for field in fields.names() {
+                            struct_body
+                                .push_parsed(format!(
+                                    "{}: bincode::de::Decode::decode(&mut decoder)?,",
+                                    field.to_string()
+                                ))
+                                .unwrap();
+                        }
+                    });
+                });
+            })
+            .unwrap();
+
+        Ok(())
+    }
+
+    pub fn generate_borrow_decode(self, generator: &mut Generator) -> Result<()> {
+        // Remember to keep this mostly in sync with generate_decode
+        let DeriveStruct { fields } = self;
+
+        generator
+            .impl_for_with_de_lifetime("bincode::de::BorrowDecode<'__de>")
+            .unwrap()
+            .generate_fn("borrow_decode")
+            .with_generic("D", ["bincode::de::BorrowDecoder<'__de>"])
+            .with_arg("mut decoder", "D")
+            .with_return_type("core::result::Result<Self, bincode::error::DecodeError>")
+            .body(|fn_body| {
+                // Ok(Self {
+                fn_body.ident_str("Ok");
+                fn_body.group(Delimiter::Parenthesis, |ok_group| {
+                    ok_group.ident_str("Self");
+                    ok_group.group(Delimiter::Brace, |struct_body| {
+                        for field in fields.names() {
+                            struct_body
+                                .push_parsed(format!(
                                     "{}: bincode::de::BorrowDecode::borrow_decode(&mut decoder)?,",
                                     field.to_string()
                                 ))
-                                    .unwrap();
-                            }
-                        });
+                                .unwrap();
+                        }
                     });
-                })
-                .unwrap();
+                });
+            })
+            .unwrap();
 
-            Ok(())
-        } else {
-            // struct has no lifetimes, implement Decode
-
-            generator
-                .impl_for("bincode::de::Decode")
-                .unwrap()
-                .generate_fn("decode")
-                .with_generic("D", ["bincode::de::Decoder"])
-                .with_arg("mut decoder", "D")
-                .with_return_type("core::result::Result<Self, bincode::error::DecodeError>")
-                .body(|fn_body| {
-                    // Ok(Self {
-                    fn_body.ident_str("Ok");
-                    fn_body.group(Delimiter::Parenthesis, |ok_group| {
-                        ok_group.ident_str("Self");
-                        ok_group.group(Delimiter::Brace, |struct_body| {
-                            // Fields
-                            // {
-                            //      a: bincode::de::Decode::decode(&mut decoder)?,
-                            //      b: bincode::de::Decode::decode(&mut decoder)?,
-                            //      ...
-                            // }
-                            for field in fields.names() {
-                                struct_body
-                                    .push_parsed(format!(
-                                        "{}: bincode::de::Decode::decode(&mut decoder)?,",
-                                        field.to_string()
-                                    ))
-                                    .unwrap();
-                            }
-                        });
-                    });
-                })
-                .unwrap();
-
-            Ok(())
-        }
+        Ok(())
     }
 }

--- a/derive/src/generate/generator.rs
+++ b/derive/src/generate/generator.rs
@@ -43,14 +43,6 @@ impl Generator {
         ImplFor::new_with_de_lifetime(self, trait_name)
     }
 
-    /// Returns `true` if the struct or enum has lifetimes.
-    pub fn has_lifetimes(&self) -> bool {
-        self.generics
-            .as_ref()
-            .map(|g| g.has_lifetime())
-            .unwrap_or(false)
-    }
-
     /// Consume the contents of this generator. This *must* be called, or else the generator will panic on drop.
     pub fn take_stream(mut self) -> TokenStream {
         std::mem::take(&mut self.stream).stream

--- a/src/features/derive.rs
+++ b/src/features/derive.rs
@@ -1,2 +1,2 @@
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
-pub use bincode_derive::{Decode, Encode};
+pub use bincode_derive::{BorrowDecode, Decode, Encode};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! |std   | Yes    ||`decode_from_reader` and `encode_into_writer`|
 //! |alloc | Yes    |All common containers in alloc, like `Vec`, `String`, `Box`|`encode_to_vec`|
 //! |atomic| Yes    |All `Atomic*` integer types, e.g. `AtomicUsize`, and `AtomicBool`||
-//! |derive| Yes    |||Enables the `Encode` and `Decode` derive macro|
+//! |derive| Yes    |||Enables the `BorrowDecode`, `Decode` and `Encode` derive macros|
 //! |serde | No     |TODO|TODO|TODO|
 //!
 //! # Example
@@ -76,6 +76,9 @@ pub mod config;
 pub mod de;
 pub mod enc;
 pub mod error;
+
+pub use de::{BorrowDecode, Decode};
+pub use enc::Encode;
 
 use config::Config;
 

--- a/tests/alloc.rs
+++ b/tests/alloc.rs
@@ -28,13 +28,13 @@ impl bincode::enc::Encode for Foo {
     }
 }
 
-impl bincode::de::Decode for Foo {
+impl bincode::Decode for Foo {
     fn decode<D: bincode::de::Decoder>(
         mut decoder: D,
     ) -> Result<Self, bincode::error::DecodeError> {
         Ok(Self {
-            a: bincode::de::Decode::decode(&mut decoder)?,
-            b: bincode::de::Decode::decode(&mut decoder)?,
+            a: bincode::Decode::decode(&mut decoder)?,
+            b: bincode::Decode::decode(&mut decoder)?,
         })
     }
 }

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -17,7 +17,7 @@ pub struct Test2<T: Decode> {
     c: u32,
 }
 
-#[derive(bincode::Decode, PartialEq, Debug, Eq)]
+#[derive(bincode::BorrowDecode, PartialEq, Debug, Eq)]
 pub struct Test3<'a> {
     a: &'a str,
     b: u32,
@@ -34,7 +34,7 @@ pub enum TestEnum {
     Baz(u32, u32, u32),
 }
 
-#[derive(bincode::Encode, bincode::Decode, PartialEq, Debug, Eq)]
+#[derive(bincode::Encode, bincode::BorrowDecode, PartialEq, Debug, Eq)]
 pub enum TestEnum2<'a> {
     Foo,
     Bar { name: &'a str },

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -1,0 +1,2 @@
+#[path = "issues/issue_431.rs"]
+mod issue_431;

--- a/tests/issues/issue_431.rs
+++ b/tests/issues/issue_431.rs
@@ -1,0 +1,29 @@
+#![cfg(all(feature = "std", feature = "derive"))]
+
+use bincode::{config::Configuration, de::Decode, enc::Encode, Decode, Encode};
+use std::borrow::Cow;
+
+#[derive(Encode, Decode, PartialEq, Debug)]
+struct T<'a, A: Clone + Encode + Decode> {
+    t: Cow<'a, U<'a, A>>,
+}
+
+#[derive(Clone, Encode, Decode, PartialEq, Debug)]
+struct U<'a, A: Clone + Encode + Decode> {
+    u: Cow<'a, A>,
+}
+
+#[test]
+fn test() {
+    let u = U {
+        u: Cow::Owned(String::from("Hello world")),
+    };
+    let t = T {
+        t: Cow::Borrowed(&u),
+    };
+    let vec = bincode::encode_to_vec(&t, Configuration::standard()).unwrap();
+
+    let decoded: T<String> = bincode::decode_from_slice(&vec, Configuration::standard()).unwrap();
+
+    assert_eq!(t, decoded);
+}

--- a/tests/issues/issue_431.rs
+++ b/tests/issues/issue_431.rs
@@ -1,6 +1,6 @@
 #![cfg(all(feature = "std", feature = "derive"))]
 
-use bincode::{config::Configuration, de::Decode, enc::Encode, Decode, Encode};
+use bincode::{config::Configuration, Decode, Encode};
 use std::borrow::Cow;
 
 #[derive(Encode, Decode, PartialEq, Debug)]

--- a/tests/std.rs
+++ b/tests/std.rs
@@ -30,13 +30,13 @@ impl bincode::enc::Encode for Foo {
     }
 }
 
-impl bincode::de::Decode for Foo {
+impl bincode::Decode for Foo {
     fn decode<D: bincode::de::Decoder>(
         mut decoder: D,
     ) -> Result<Self, bincode::error::DecodeError> {
         Ok(Self {
-            a: bincode::de::Decode::decode(&mut decoder)?,
-            b: bincode::de::Decode::decode(&mut decoder)?,
+            a: bincode::Decode::decode(&mut decoder)?,
+            b: bincode::Decode::decode(&mut decoder)?,
         })
     }
 }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -3,7 +3,7 @@ use core::fmt::Debug;
 
 fn the_same_with_config<V, C, CMP>(element: &V, config: C, cmp: CMP)
 where
-    V: bincode::enc::Encode + bincode::de::Decode + Debug + 'static,
+    V: bincode::enc::Encode + bincode::Decode + Debug + 'static,
     C: Config,
     CMP: Fn(&V, &V) -> bool,
 {
@@ -28,7 +28,7 @@ where
 
 pub fn the_same_with_comparer<V, CMP>(element: V, cmp: CMP)
 where
-    V: bincode::enc::Encode + bincode::de::Decode + Debug + 'static,
+    V: bincode::enc::Encode + bincode::Decode + Debug + 'static,
     CMP: Fn(&V, &V) -> bool,
 {
     // A matrix of each different config option possible
@@ -101,7 +101,7 @@ where
 #[allow(dead_code)] // This is not used in every test
 pub fn the_same<V>(element: V)
 where
-    V: bincode::enc::Encode + bincode::de::Decode + PartialEq + Debug + 'static,
+    V: bincode::enc::Encode + bincode::Decode + PartialEq + Debug + 'static,
 {
     the_same_with_comparer(element, |a, b| a == b);
 }


### PR DESCRIPTION
We've discussed splitting off `Decode` from `BorrowDecode` derive macro before. This PR actualizes that.

This should offer people a solution to issues where the type implements `BorrowDecode` while people are explicitly requesting `Decode`. It does not fix the issue around `Cow<T>` always needing `Decode`, we can't fix that until specialization implementation.