### PR TITLE
Allow serde types to be Decode/Encoded

### DIFF
--- a/derive/src/derive_struct.rs
+++ b/derive/src/derive_struct.rs
@@ -1,5 +1,5 @@
 use crate::generate::Generator;
-use crate::parse::Fields;
+use crate::parse::{FieldAttribute, Fields};
 use crate::prelude::Delimiter;
 use crate::Result;
 
@@ -21,12 +21,21 @@ impl DeriveStruct {
             .with_return_type("core::result::Result<(), bincode::error::EncodeError>")
             .body(|fn_body| {
                 for field in fields.names() {
-                    fn_body
-                        .push_parsed(format!(
-                            "bincode::enc::Encode::encode(&self.{}, &mut encoder)?;",
-                            field.to_string()
-                        ))
-                        .unwrap();
+                    if field.has_field_attribute(FieldAttribute::WithSerde) {
+                        fn_body
+                            .push_parsed(format!(
+                                "bincode::__serde_encode_field(&self.{}, &mut encoder)?;",
+                                field.to_string()
+                            ))
+                            .unwrap();
+                    } else {
+                        fn_body
+                            .push_parsed(format!(
+                                "bincode::enc::Encode::encode(&self.{}, &mut encoder)?;",
+                                field.to_string()
+                            ))
+                            .unwrap();
+                    }
                 }
                 fn_body.push_parsed("Ok(())").unwrap();
             })
@@ -59,12 +68,21 @@ impl DeriveStruct {
                         //      ...
                         // }
                         for field in fields.names() {
-                            struct_body
-                                .push_parsed(format!(
-                                    "{}: bincode::Decode::decode(&mut decoder)?,",
-                                    field.to_string()
-                                ))
-                                .unwrap();
+                            if field.has_field_attribute(FieldAttribute::WithSerde) {
+                                struct_body
+                                    .push_parsed(format!(
+                                        "{}: bincode::__serde_decode_field(&mut decoder)?,",
+                                        field.to_string()
+                                    ))
+                                    .unwrap();
+                            } else {
+                                struct_body
+                                    .push_parsed(format!(
+                                        "{}: bincode::Decode::decode(&mut decoder)?,",
+                                        field.to_string()
+                                    ))
+                                    .unwrap();
+                            }
                         }
                     });
                 });
@@ -92,12 +110,21 @@ impl DeriveStruct {
                     ok_group.ident_str("Self");
                     ok_group.group(Delimiter::Brace, |struct_body| {
                         for field in fields.names() {
-                            struct_body
-                                .push_parsed(format!(
-                                    "{}: bincode::de::BorrowDecode::borrow_decode(&mut decoder)?,",
-                                    field.to_string()
-                                ))
-                                .unwrap();
+                            if field.has_field_attribute(FieldAttribute::WithSerde) {
+                                struct_body
+                                    .push_parsed(format!(
+                                        "{}: bincode::__serde_decode_borrowed_field(&mut decoder)?,",
+                                        field.to_string()
+                                    ))
+                                    .unwrap();
+                            } else {
+                                struct_body
+                                    .push_parsed(format!(
+                                        "{}: bincode::de::BorrowDecode::borrow_decode(&mut decoder)?,",
+                                        field.to_string()
+                                    ))
+                                    .unwrap();
+                                }
                         }
                     });
                 });

--- a/derive/src/derive_struct.rs
+++ b/derive/src/derive_struct.rs
@@ -24,7 +24,7 @@ impl DeriveStruct {
                     if field.has_field_attribute(FieldAttribute::WithSerde) {
                         fn_body
                             .push_parsed(format!(
-                                "bincode::__serde_encode_field(&self.{}, &mut encoder)?;",
+                                "bincode::Encode::encode(&bincode::serde::Compat(&self.{}), &mut encoder)?;",
                                 field.to_string()
                             ))
                             .unwrap();
@@ -71,7 +71,7 @@ impl DeriveStruct {
                             if field.has_field_attribute(FieldAttribute::WithSerde) {
                                 struct_body
                                     .push_parsed(format!(
-                                        "{}: bincode::__serde_decode_field(&mut decoder)?,",
+                                        "{}: (<bincode::serde::Compat<_> as bincode::Decode>::decode(&mut decoder)?).0,",
                                         field.to_string()
                                     ))
                                     .unwrap();
@@ -113,7 +113,7 @@ impl DeriveStruct {
                             if field.has_field_attribute(FieldAttribute::WithSerde) {
                                 struct_body
                                     .push_parsed(format!(
-                                        "{}: bincode::__serde_decode_borrowed_field(&mut decoder)?,",
+                                        "{}: (<bincode::serde::BorrowCompat<_> as bincode::de::BorrowDecode>::borrow_decode(&mut decoder)?).0,",
                                         field.to_string()
                                     ))
                                     .unwrap();

--- a/derive/src/error.rs
+++ b/derive/src/error.rs
@@ -9,7 +9,7 @@ pub enum Error {
 }
 
 impl Error {
-    pub fn wrong_token<T>(token: Option<&TokenTree>, expected: &'static str) -> Result<T, Self> {
+    pub fn wrong_token<T>(token: Option<&TokenTree>, expected: &str) -> Result<T, Self> {
         Err(Self::InvalidRustSyntax {
             span: token.map(|t| t.span()).unwrap_or_else(Span::call_site),
             expected: format!("{}, got {:?}", expected, token),

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -16,11 +16,12 @@ pub(crate) mod prelude {
 }
 
 use error::Error;
+use parse::AttributeLocation;
 use prelude::TokenStream;
 
 type Result<T = ()> = std::result::Result<T, Error>;
 
-#[proc_macro_derive(Encode)]
+#[proc_macro_derive(Encode, attributes(bincode))]
 pub fn derive_encode(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     #[allow(clippy::useless_conversion)]
     derive_encode_inner(input.into())
@@ -31,7 +32,7 @@ pub fn derive_encode(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 fn derive_encode_inner(input: TokenStream) -> Result<TokenStream> {
     let source = &mut input.into_iter().peekable();
 
-    let _attributes = parse::Attribute::try_take(source)?;
+    let _attributes = parse::Attribute::try_take(AttributeLocation::Container, source)?;
     let _visibility = parse::Visibility::try_take(source)?;
     let (datatype, name) = parse::DataType::take(source)?;
     let generics = parse::Generics::try_take(source)?;
@@ -61,7 +62,7 @@ fn derive_encode_inner(input: TokenStream) -> Result<TokenStream> {
     Ok(stream)
 }
 
-#[proc_macro_derive(Decode)]
+#[proc_macro_derive(Decode, attributes(bincode))]
 pub fn derive_decode(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     #[allow(clippy::useless_conversion)]
     derive_decode_inner(input.into())
@@ -72,7 +73,7 @@ pub fn derive_decode(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 fn derive_decode_inner(input: TokenStream) -> Result<TokenStream> {
     let source = &mut input.into_iter().peekable();
 
-    let _attributes = parse::Attribute::try_take(source)?;
+    let _attributes = parse::Attribute::try_take(AttributeLocation::Container, source)?;
     let _visibility = parse::Visibility::try_take(source)?;
     let (datatype, name) = parse::DataType::take(source)?;
     let generics = parse::Generics::try_take(source)?;
@@ -102,7 +103,7 @@ fn derive_decode_inner(input: TokenStream) -> Result<TokenStream> {
     Ok(stream)
 }
 
-#[proc_macro_derive(BorrowDecode)]
+#[proc_macro_derive(BorrowDecode, attributes(bincode))]
 pub fn derive_brrow_decode(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     #[allow(clippy::useless_conversion)]
     derive_borrow_decode_inner(input.into())
@@ -113,7 +114,7 @@ pub fn derive_brrow_decode(input: proc_macro::TokenStream) -> proc_macro::TokenS
 fn derive_borrow_decode_inner(input: TokenStream) -> Result<TokenStream> {
     let source = &mut input.into_iter().peekable();
 
-    let _attributes = parse::Attribute::try_take(source)?;
+    let _attributes = parse::Attribute::try_take(AttributeLocation::Container, source)?;
     let _visibility = parse::Visibility::try_take(source)?;
     let (datatype, name) = parse::DataType::take(source)?;
     let generics = parse::Generics::try_take(source)?;

--- a/derive/src/parse/attributes.rs
+++ b/derive/src/parse/attributes.rs
@@ -83,16 +83,20 @@ impl Attribute {
         loc: AttributeLocation,
         stream: &mut Peekable<impl Iterator<Item = TokenTree>>,
     ) -> Result<Self> {
-        match stream.next() {
-            Some(TokenTree::Ident(i))
-                if ident_eq(&i, "with_serde") && loc == AttributeLocation::Field =>
+        match (stream.next(), loc) {
+            (Some(TokenTree::Ident(ident)), AttributeLocation::Field)
+                if ident_eq(&ident, "with_serde") =>
             {
                 Ok(Self::Field(FieldAttribute::WithSerde))
             }
-            ident @ Some(TokenTree::Ident(_)) => {
-                Error::wrong_token(ident.as_ref(), "one of: `with_serde`")
+            (token @ Some(TokenTree::Ident(_)), AttributeLocation::Field) => {
+                Error::wrong_token(token.as_ref(), "one of: `with_serde`")
             }
-            token => Error::wrong_token(token.as_ref(), "ident"),
+            (token @ Some(TokenTree::Ident(_)), loc) => Error::wrong_token(
+                token.as_ref(),
+                &format!("{:?} attributes not supported", loc),
+            ),
+            (token, _) => Error::wrong_token(token.as_ref(), "ident"),
         }
     }
 }

--- a/derive/src/parse/attributes.rs
+++ b/derive/src/parse/attributes.rs
@@ -1,28 +1,62 @@
-use super::{assume_group, assume_punct};
-use crate::parse::consume_punct_if;
+use super::{assume_group, assume_ident, assume_punct};
+use crate::parse::{consume_punct_if, ident_eq};
 use crate::prelude::{Delimiter, Group, Punct, TokenTree};
 use crate::{Error, Result};
 use std::iter::Peekable;
 
 #[derive(Debug)]
-pub struct Attribute {
-    // we don't use these fields yet
-    #[allow(dead_code)]
-    punct: Punct,
-    #[allow(dead_code)]
-    tokens: Option<Group>,
+pub enum Attribute {
+    Field(FieldAttribute),
+    Unknown { punct: Punct, tokens: Option<Group> },
+}
+#[derive(Debug, PartialEq)]
+pub enum FieldAttribute {
+    /// The field is a serde type and should implement Encode/Decode through a wrapper
+    WithSerde,
+}
+
+#[derive(PartialEq, Eq, Debug, Hash, Copy, Clone)]
+pub enum AttributeLocation {
+    Container,
+    Variant,
+    Field,
 }
 
 impl Attribute {
-    pub fn try_take(input: &mut Peekable<impl Iterator<Item = TokenTree>>) -> Result<Vec<Self>> {
+    pub fn try_take(
+        loc: AttributeLocation,
+        input: &mut Peekable<impl Iterator<Item = TokenTree>>,
+    ) -> Result<Vec<Self>> {
         let mut result = Vec::new();
 
         while let Some(punct) = consume_punct_if(input, '#') {
             match input.peek() {
                 Some(TokenTree::Group(g)) if g.delimiter() == Delimiter::Bracket => {
-                    result.push(Attribute {
+                    let group = assume_group(input.next());
+                    let stream = &mut group.stream().into_iter().peekable();
+                    if let Some(TokenTree::Ident(attribute_ident)) = stream.peek() {
+                        if super::ident_eq(attribute_ident, "bincode") {
+                            assume_ident(stream.next());
+                            match stream.next() {
+                                Some(TokenTree::Group(group)) => {
+                                    result.push(Self::parse_bincode_attribute(
+                                        loc,
+                                        &mut group.stream().into_iter().peekable(),
+                                    )?);
+                                }
+                                token => {
+                                    return Error::wrong_token(
+                                        token.as_ref(),
+                                        "Bracketed group of attributes",
+                                    )
+                                }
+                            }
+                            continue;
+                        }
+                    }
+                    result.push(Attribute::Unknown {
                         punct,
-                        tokens: Some(assume_group(input.next())),
+                        tokens: Some(group),
                     });
                 }
                 Some(TokenTree::Group(g)) => {
@@ -34,7 +68,7 @@ impl Attribute {
                 Some(TokenTree::Punct(p)) if p.as_char() == '#' => {
                     // sometimes with empty lines of doc comments, we get two #'s in a row
                     // add an empty attributes and continue to the next loop
-                    result.push(Attribute {
+                    result.push(Attribute::Unknown {
                         punct: assume_punct(input.next(), '#'),
                         tokens: None,
                     })
@@ -44,6 +78,23 @@ impl Attribute {
         }
         Ok(result)
     }
+
+    fn parse_bincode_attribute(
+        loc: AttributeLocation,
+        stream: &mut Peekable<impl Iterator<Item = TokenTree>>,
+    ) -> Result<Self> {
+        match stream.next() {
+            Some(TokenTree::Ident(i))
+                if ident_eq(&i, "with_serde") && loc == AttributeLocation::Field =>
+            {
+                Ok(Self::Field(FieldAttribute::WithSerde))
+            }
+            ident @ Some(TokenTree::Ident(_)) => {
+                Error::wrong_token(ident.as_ref(), "one of: `with_serde`")
+            }
+            token => Error::wrong_token(token.as_ref(), "ident"),
+        }
+    }
 }
 
 #[test]
@@ -51,14 +102,18 @@ fn test_attributes_try_take() {
     use crate::token_stream;
 
     let stream = &mut token_stream("struct Foo;");
-    assert!(Attribute::try_take(stream).unwrap().is_empty());
+    assert!(Attribute::try_take(AttributeLocation::Container, stream)
+        .unwrap()
+        .is_empty());
     match stream.next().unwrap() {
         TokenTree::Ident(i) => assert_eq!(i, "struct"),
         x => panic!("Expected ident, found {:?}", x),
     }
 
     let stream = &mut token_stream("#[cfg(test)] struct Foo;");
-    assert!(!Attribute::try_take(stream).unwrap().is_empty());
+    assert!(!Attribute::try_take(AttributeLocation::Container, stream)
+        .unwrap()
+        .is_empty());
     match stream.next().unwrap() {
         TokenTree::Ident(i) => assert_eq!(i, "struct"),
         x => panic!("Expected ident, found {:?}", x),

--- a/derive/src/parse/mod.rs
+++ b/derive/src/parse/mod.rs
@@ -8,7 +8,7 @@ mod data_type;
 mod generics;
 mod visibility;
 
-pub use self::attributes::Attribute;
+pub use self::attributes::{Attribute, AttributeLocation, FieldAttribute};
 pub use self::body::{EnumBody, EnumVariant, Fields, StructBody, UnnamedField};
 pub use self::data_type::DataType;
 pub use self::generics::{GenericConstraints, Generics, Lifetime, SimpleGeneric};

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -12,7 +12,7 @@ By default `bincode` will serialize values in little endian encoding. This can b
 
 Boolean types are encoded with 1 byte for each boolean type, with `0` being `false`, `1` being true. Whilst deserializing every other value will throw an error.
 
-All basic numeric types will be encoded based on the configured [IntEncoding](#IntEncoding).
+All basic numeric types will be encoded based on the configured [IntEncoding](#intencoding).
 
 All floating point types will take up exactly 4 (for `f32`) or 8 (for `f64`) bytes.
 

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -19,6 +19,5 @@ mod derive;
 pub use self::derive::*;
 
 #[cfg(feature = "serde")]
-mod serde;
-#[cfg(feature = "serde")]
-pub use self::serde::*;
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+pub mod serde;

--- a/src/features/serde/de_borrowed.rs
+++ b/src/features/serde/de_borrowed.rs
@@ -7,10 +7,7 @@ use core::marker::PhantomData;
 use serde_incl::de::*;
 
 /// Decode a borrowed type from the given slice. Some parts of the decoded type are expected to be referring to the given slice
-pub fn serde_decode_borrowed_from_slice<'de, T, C>(
-    slice: &'de [u8],
-    config: C,
-) -> Result<T, DecodeError>
+pub fn decode_borrowed_from_slice<'de, T, C>(slice: &'de [u8], config: C) -> Result<T, DecodeError>
 where
     T: Deserialize<'de>,
     C: Config,

--- a/src/features/serde/de_borrowed.rs
+++ b/src/features/serde/de_borrowed.rs
@@ -24,9 +24,9 @@ where
     T::deserialize(serde_decoder)
 }
 
-struct SerdeDecoder<'a, 'de, DE: BorrowDecoder<'de>> {
-    de: &'a mut DE,
-    pd: PhantomData<&'de ()>,
+pub(super) struct SerdeDecoder<'a, 'de, DE: BorrowDecoder<'de>> {
+    pub(super) de: &'a mut DE,
+    pub(super) pd: PhantomData<&'de ()>,
 }
 
 impl<'a, 'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'a, 'de, DE> {

--- a/src/features/serde/de_owned.rs
+++ b/src/features/serde/de_owned.rs
@@ -19,8 +19,8 @@ where
     T::deserialize(serde_decoder)
 }
 
-struct SerdeDecoder<'a, DE: Decoder> {
-    de: &'a mut DE,
+pub(crate) struct SerdeDecoder<'a, DE: Decoder> {
+    pub(crate) de: &'a mut DE,
 }
 
 impl<'a, 'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'a, DE> {

--- a/src/features/serde/de_owned.rs
+++ b/src/features/serde/de_owned.rs
@@ -7,8 +7,10 @@ use serde_incl::de::*;
 
 /// Decode an owned type from the given slice.
 ///
-/// Note that this does not work with borrowed types like `&str` or `&[u8]`. For that use [serde_decode_borrowed_from_slice].
-pub fn serde_decode_from_slice<T, C>(slice: &[u8], config: C) -> Result<T, DecodeError>
+/// Note that this does not work with borrowed types like `&str` or `&[u8]`. For that use [decode_borrowed_from_slice].
+///
+/// [decode_borrowed_from_slice]: fn.decode_borrowed_from_slice.html
+pub fn decode_from_slice<T, C>(slice: &[u8], config: C) -> Result<T, DecodeError>
 where
     T: DeserializeOwned,
     C: Config,

--- a/src/features/serde/mod.rs
+++ b/src/features/serde/mod.rs
@@ -30,6 +30,8 @@
 //!
 //! # Known issues
 //!
+//! Currently the `serde` feature will automatically enable the `alloc` and `std` feature. If you're running in a `#[no_std]` environment consider using bincode's own derive macros.
+//! 
 //! Because bincode is a format without meta data, there are several known issues with serde's `skip` attributes. Please do not use `skip` attributes if you plan on using bincode, or use bincode's own `derive` macros.
 //! 
 //! This includes:

--- a/src/features/serde/mod.rs
+++ b/src/features/serde/mod.rs
@@ -51,6 +51,7 @@
 //! - `#[serde(skip_serializing)]`
 //! - `#[serde(skip_deserializing)]`
 //! - `#[serde(skip_serializing_if = "path")]`
+//! - `#[serde(flatten)]`
 //!
 //! **Using any of the above attributes can and will cause issues with bincode and will result in lost data**. Consider using bincode's own derive macro instead.
 //!

--- a/src/features/serde/mod.rs
+++ b/src/features/serde/mod.rs
@@ -13,6 +13,8 @@
 //! For interop with bincode's `derive` feature, you can use the `#[bincode(with_serde)]` attribute on each field that implements serde's traits.
 //!
 //! ```
+//! # #[cfg(feature = "derive")]
+//! # mod foo {
 //! # use bincode::{Decode, Encode};
 //! # use serde_derive::{Deserialize, Serialize};
 //! #[derive(Serialize, Deserialize)]
@@ -35,6 +37,7 @@
 //!         serde: SerdeType,
 //!     },
 //! }
+//! # }
 //! ```
 //!
 //! # Known issues

--- a/src/features/serde/mod.rs
+++ b/src/features/serde/mod.rs
@@ -26,3 +26,61 @@ impl serde_incl::ser::Error for crate::error::EncodeError {
         Self::OtherString(msg.to_string())
     }
 }
+
+/// Wrapper struct that implements [Decode] and [Encode] on any type that implements serde's [DeserializeOwned] and [Serialize] respectively.
+pub struct SerdeToBincode<T>(pub T);
+
+impl<T> crate::Decode for SerdeToBincode<T>
+where
+    T: serde_incl::de::DeserializeOwned,
+{
+    fn decode<D: crate::de::Decoder>(decoder: D) -> Result<Self, crate::error::DecodeError> {
+        let t: T = __serde_decode_field(decoder)?;
+        Ok(Self(t))
+    }
+}
+
+impl<T> crate::Encode for SerdeToBincode<T>
+where
+    T: serde_incl::Serialize,
+{
+    fn encode<E: crate::enc::Encoder>(&self, encoder: E) -> Result<(), crate::error::EncodeError> {
+        __serde_encode_field(&self.0, encoder)
+    }
+}
+
+#[doc(hidden)]
+pub fn __serde_encode_field<T, E>(value: T, mut encoder: E) -> Result<(), crate::error::EncodeError>
+where
+    T: serde_incl::Serialize,
+    E: crate::enc::Encoder,
+{
+    let serializer = ser::SerdeEncoder { enc: &mut encoder };
+    value.serialize(serializer)?;
+    Ok(())
+}
+
+#[doc(hidden)]
+pub fn __serde_decode_field<T, D>(mut decoder: D) -> Result<T, crate::error::DecodeError>
+where
+    T: serde_incl::de::DeserializeOwned,
+    D: crate::de::Decoder,
+{
+    let serde_decoder = de_owned::SerdeDecoder { de: &mut decoder };
+    T::deserialize(serde_decoder)
+}
+
+#[doc(hidden)]
+pub fn __serde_decode_borrow_field<'de, T, D>(
+    mut decoder: D,
+) -> Result<T, crate::error::DecodeError>
+where
+    T: serde_incl::de::Deserialize<'de>,
+    D: crate::de::BorrowDecoder<'de> + 'de,
+{
+    let serde_decoder = de_borrowed::SerdeDecoder {
+        de: &mut decoder,
+        pd: core::marker::PhantomData,
+    };
+    T::deserialize(serde_decoder)
+}

--- a/src/features/serde/mod.rs
+++ b/src/features/serde/mod.rs
@@ -1,47 +1,56 @@
 //! Support for serde integration. Enable this with the `serde` feature.
-//! 
+//!
 //! To encode/decode type that implement serde's trait, you can use:
 //! - [decode_borrowed_from_slice]
 //! - [decode_from_slice]
 //! - [encode_to_slice]
 //! - [encode_to_vec]
-//! 
+//!
 //! For interop with bincode's [Decode]/[Encode], you can use:
 //! - [Compat]
 //! - [BorrowCompat]
-//! 
+//!
 //! For interop with bincode's `derive` feature, you can use the `#[bincode(with_serde)]` attribute on each field that implements serde's traits.
-//! 
+//!
 //! ```
 //! # use bincode::{Decode, Encode};
 //! # use serde_derive::{Deserialize, Serialize};
 //! #[derive(Serialize, Deserialize)]
 //! # #[serde(crate = "serde_incl")]
 //! pub struct SerdeType {
-//!     // ... 
+//!     // ...
 //! }
 //!
 //! #[derive(Decode, Encode)]
-//! pub struct BincodeWithSerde {
+//! pub struct StructWithSerde {
 //!     #[bincode(with_serde)]
 //!     pub serde: SerdeType,
+//! }
+//!
+//! #[derive(Decode, Encode)]
+//! pub enum EnumWithSerde {
+//!     Unit(#[bincode(with_serde)] SerdeType),
+//!     Struct {
+//!         #[bincode(with_serde)]
+//!         serde: SerdeType,
+//!     },
 //! }
 //! ```
 //!
 //! # Known issues
 //!
 //! Currently the `serde` feature will automatically enable the `alloc` and `std` feature. If you're running in a `#[no_std]` environment consider using bincode's own derive macros.
-//! 
+//!
 //! Because bincode is a format without meta data, there are several known issues with serde's `skip` attributes. Please do not use `skip` attributes if you plan on using bincode, or use bincode's own `derive` macros.
-//! 
+//!
 //! This includes:
 //! - `#[serde(skip)]`
 //! - `#[serde(skip_serializing)]`
 //! - `#[serde(skip_deserializing)]`
 //! - `#[serde(skip_serializing_if = "path")]`
-//! 
+//!
 //! **Using any of the above attributes can and will cause issues with bincode and will result in lost data**. Consider using bincode's own derive macro instead.
-//! 
+//!
 //! [Decode]: ../de/trait.Decode.html
 //! [Encode]: ../enc/trait.Encode.html
 

--- a/src/features/serde/ser.rs
+++ b/src/features/serde/ser.rs
@@ -9,7 +9,8 @@ use serde_incl::ser::*;
 
 #[cfg(feature = "alloc")]
 /// Encode a `serde` `Serialize` type into a `Vec<u8>` with the bincode algorithm
-pub fn serde_encode_to_vec<T, C>(t: T, config: C) -> Result<Vec<u8>, EncodeError>
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub fn encode_to_vec<T, C>(t: T, config: C) -> Result<Vec<u8>, EncodeError>
 where
     T: Serialize,
     C: Config,
@@ -21,7 +22,7 @@ where
 }
 
 /// Encode a `serde` `Serialize` type into a given byte slice with the bincode algorithm
-pub fn serde_encode_to_slice<T, C>(t: T, slice: &mut [u8], config: C) -> Result<usize, EncodeError>
+pub fn encode_to_slice<T, C>(t: T, slice: &mut [u8], config: C) -> Result<usize, EncodeError>
 where
     T: Serialize,
     C: Config,

--- a/src/features/serde/ser.rs
+++ b/src/features/serde/ser.rs
@@ -33,8 +33,8 @@ where
     Ok(encoder.into_writer().bytes_written())
 }
 
-struct SerdeEncoder<'a, ENC: Encoder> {
-    enc: &'a mut ENC,
+pub(super) struct SerdeEncoder<'a, ENC: Encoder> {
+    pub(super) enc: &'a mut ENC,
 }
 
 impl<'a, ENC> Serializer for SerdeEncoder<'a, ENC>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //! |alloc | Yes    |All common containers in alloc, like `Vec`, `String`, `Box`|`encode_to_vec`|
 //! |atomic| Yes    |All `Atomic*` integer types, e.g. `AtomicUsize`, and `AtomicBool`||
 //! |derive| Yes    |||Enables the `BorrowDecode`, `Decode` and `Encode` derive macros|
-//! |serde | No     |TODO|TODO|TODO|
+//! |serde | No     |`Compat` and `BorrowCompat`, which will work for all types that implement serde's traits|serde-specific encode/decode functions in the [serde] module|Note: There are several [known issues](serde/index.html#known-issues) when using serde and bincode|
 //!
 //! # Example
 //!

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -125,3 +125,36 @@ fn test_serialize_deserialize_owned_data() {
         output
     );
 }
+
+#[cfg(feature = "derive")]
+mod derive {
+    use bincode::{config::Configuration, Decode, Encode};
+    use serde_derive::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    #[serde(crate = "serde_incl")]
+    pub struct SerdeType {
+        pub a: u32,
+    }
+
+    #[derive(Decode, Encode, PartialEq, Debug)]
+    pub struct BincodeWithSerde {
+        #[bincode(with_serde)]
+        pub serde: SerdeType,
+    }
+
+    #[test]
+    fn test_serde_derive() {
+        let start = BincodeWithSerde {
+            serde: SerdeType { a: 5 },
+        };
+        let mut slice = [0u8; 100];
+        let len =
+            bincode::encode_into_slice(&start, &mut slice, Configuration::standard()).unwrap();
+        let slice = &slice[..len];
+        let result: BincodeWithSerde =
+            bincode::decode_from_slice(&slice, Configuration::standard()).unwrap();
+
+        assert_eq!(start, result);
+    }
+}

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -61,16 +61,16 @@ fn test_serialize_deserialize_borrowed_data() {
 
     let mut result = [0u8; 20];
     let len =
-        bincode::serde_encode_to_slice(&input, &mut result, Configuration::standard()).unwrap();
+        bincode::serde::encode_to_slice(&input, &mut result, Configuration::standard()).unwrap();
     let result = &result[..len];
     assert_eq!(result, expected);
 
-    let result = bincode::serde_encode_to_vec(&input, Configuration::standard()).unwrap();
+    let result = bincode::serde::encode_to_vec(&input, Configuration::standard()).unwrap();
 
     assert_eq!(result, expected);
 
     let output: SerdeWithBorrowedData =
-        bincode::serde_decode_borrowed_from_slice(&result, Configuration::standard()).unwrap();
+        bincode::serde::decode_borrowed_from_slice(&result, Configuration::standard()).unwrap();
     assert_eq!(
         SerdeWithBorrowedData {
             b: 0, // remember: b is skipped
@@ -107,16 +107,16 @@ fn test_serialize_deserialize_owned_data() {
 
     let mut result = [0u8; 20];
     let len =
-        bincode::serde_encode_to_slice(&input, &mut result, Configuration::standard()).unwrap();
+        bincode::serde::encode_to_slice(&input, &mut result, Configuration::standard()).unwrap();
     let result = &result[..len];
     assert_eq!(result, expected);
 
-    let result = bincode::serde_encode_to_vec(&input, Configuration::standard()).unwrap();
+    let result = bincode::serde::encode_to_vec(&input, Configuration::standard()).unwrap();
 
     assert_eq!(result, expected);
 
     let output: SerdeWithOwnedData =
-        bincode::serde_decode_from_slice(&result, Configuration::standard()).unwrap();
+        bincode::serde::decode_from_slice(&result, Configuration::standard()).unwrap();
     assert_eq!(
         SerdeWithOwnedData {
             b: 0, // remember: b is skipped


### PR DESCRIPTION
Adds an attribute that users can add to struct fields
```rust
#[derive(bincode::Encode, bincode::Decode)]
struct Foo {
    #[bincode(with_serde)]
    serde: SerdeType
}
```

Also adds a struct that will wrap any serde type and implements `Decode` and `Encode` on it

Closes #433 