### PR TITLE
Feature/config limit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,10 @@ rand = "0.8"
 name = "varint"
 harness = false
 
+[[bench]]
+name = "inline"
+harness = false
+
 [profile.bench]
 codegen-units = 1
 debug = 1

--- a/benches/inline.rs
+++ b/benches/inline.rs
@@ -4,10 +4,7 @@ use bincode::config::Configuration;
 
 fn inline_decoder_claim_bytes_read(c: &mut Criterion) {
     let config = Configuration::standard().with_limit::<100000>();
-    let slice = bincode::encode_to_vec(vec![
-		String::from("Hello world");
-		1000
-	], config).unwrap();
+    let slice = bincode::encode_to_vec(vec![String::from("Hello world"); 1000], config).unwrap();
 
     c.bench_function("inline_decoder_claim_bytes_read", |b| {
         b.iter(|| {

--- a/benches/inline.rs
+++ b/benches/inline.rs
@@ -1,0 +1,21 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use bincode::config::Configuration;
+
+fn inline_decoder_claim_bytes_read(c: &mut Criterion) {
+    let config = Configuration::standard().with_limit::<100000>();
+    let slice = bincode::encode_to_vec(vec![
+		String::from("Hello world");
+		1000
+	], config).unwrap();
+
+    c.bench_function("inline_decoder_claim_bytes_read", |b| {
+        b.iter(|| {
+            let _: Vec<String> =
+                black_box(bincode::decode_from_slice(black_box(&slice), config).unwrap());
+        })
+    });
+}
+
+criterion_group!(benches, inline_decoder_claim_bytes_read);
+criterion_main!(benches);

--- a/src/config.rs
+++ b/src/config.rs
@@ -266,7 +266,7 @@ mod internal {
         const ENDIAN: Endian;
     }
 
-    impl<E: InternalEndianConfig, I, A> InternalEndianConfig for Configuration<E, I, A> {
+    impl<E: InternalEndianConfig, I, A, L> InternalEndianConfig for Configuration<E, I, A, L> {
         const ENDIAN: Endian = E::ENDIAN;
     }
 
@@ -280,7 +280,9 @@ mod internal {
         const INT_ENCODING: IntEncoding;
     }
 
-    impl<E, I: InternalIntEncodingConfig, A> InternalIntEncodingConfig for Configuration<E, I, A> {
+    impl<E, I: InternalIntEncodingConfig, A, L> InternalIntEncodingConfig
+        for Configuration<E, I, A, L>
+    {
         const INT_ENCODING: IntEncoding = I::INT_ENCODING;
     }
 
@@ -294,7 +296,9 @@ mod internal {
         const SKIP_FIXED_ARRAY_LENGTH: bool;
     }
 
-    impl<E, I, A: InternalArrayLengthConfig> InternalArrayLengthConfig for Configuration<E, I, A> {
+    impl<E, I, A: InternalArrayLengthConfig, L> InternalArrayLengthConfig
+        for Configuration<E, I, A, L>
+    {
         const SKIP_FIXED_ARRAY_LENGTH: bool = A::SKIP_FIXED_ARRAY_LENGTH;
     }
 

--- a/src/de/decoder.rs
+++ b/src/de/decoder.rs
@@ -61,6 +61,7 @@ impl<R: Reader, C: Config> Decoder for DecoderImpl<R, C> {
         &self.config
     }
 
+    #[inline]
     fn claim_bytes_read(&mut self, n: usize) -> Result<(), DecodeError> {
         // C::LIMIT is a const so this check should get compiled away
         if let Some(limit) = C::LIMIT {
@@ -79,6 +80,7 @@ impl<R: Reader, C: Config> Decoder for DecoderImpl<R, C> {
         }
     }
 
+    #[inline]
     fn unclaim_bytes_read(&mut self, n: usize) {
         // C::LIMIT is a const so this check should get compiled away
         if C::LIMIT.is_some() {

--- a/src/de/impls.rs
+++ b/src/de/impls.rs
@@ -448,7 +448,7 @@ where
             }
         }
 
-        decoder.claim_bytes_read(N * core::mem::size_of::<T>())?;
+        decoder.claim_bytes_read(core::mem::size_of::<[T; N]>())?;
 
         // Optimize for `[u8; N]`
         if TypeId::of::<u8>() == TypeId::of::<T>() {

--- a/src/de/impls.rs
+++ b/src/de/impls.rs
@@ -33,6 +33,7 @@ impl Decode for bool {
 impl Decode for u8 {
     #[inline]
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
+        decoder.claim_bytes_read(1)?;
         if let Some(buf) = decoder.reader().peek_read(1) {
             let byte = buf[0];
             decoder.reader().consume(1);
@@ -55,6 +56,7 @@ impl Decode for NonZeroU8 {
 
 impl Decode for u16 {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
+        decoder.claim_bytes_read(2)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
                 crate::varint::varint_decode_u16(decoder.reader(), D::C::ENDIAN)
@@ -81,6 +83,7 @@ impl Decode for NonZeroU16 {
 
 impl Decode for u32 {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
+        decoder.claim_bytes_read(4)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
                 crate::varint::varint_decode_u32(decoder.reader(), D::C::ENDIAN)
@@ -107,6 +110,7 @@ impl Decode for NonZeroU32 {
 
 impl Decode for u64 {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
+        decoder.claim_bytes_read(8)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
                 crate::varint::varint_decode_u64(decoder.reader(), D::C::ENDIAN)
@@ -133,6 +137,7 @@ impl Decode for NonZeroU64 {
 
 impl Decode for u128 {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
+        decoder.claim_bytes_read(16)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
                 crate::varint::varint_decode_u128(decoder.reader(), D::C::ENDIAN)
@@ -159,6 +164,7 @@ impl Decode for NonZeroU128 {
 
 impl Decode for usize {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
+        decoder.claim_bytes_read(8)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
                 crate::varint::varint_decode_usize(decoder.reader(), D::C::ENDIAN)
@@ -185,6 +191,7 @@ impl Decode for NonZeroUsize {
 
 impl Decode for i8 {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
+        decoder.claim_bytes_read(1)?;
         let mut bytes = [0u8; 1];
         decoder.reader().read(&mut bytes)?;
         Ok(bytes[0] as i8)
@@ -201,6 +208,7 @@ impl Decode for NonZeroI8 {
 
 impl Decode for i16 {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
+        decoder.claim_bytes_read(2)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
                 crate::varint::varint_decode_i16(decoder.reader(), D::C::ENDIAN)
@@ -227,6 +235,7 @@ impl Decode for NonZeroI16 {
 
 impl Decode for i32 {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
+        decoder.claim_bytes_read(4)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
                 crate::varint::varint_decode_i32(decoder.reader(), D::C::ENDIAN)
@@ -253,6 +262,7 @@ impl Decode for NonZeroI32 {
 
 impl Decode for i64 {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
+        decoder.claim_bytes_read(8)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
                 crate::varint::varint_decode_i64(decoder.reader(), D::C::ENDIAN)
@@ -279,6 +289,7 @@ impl Decode for NonZeroI64 {
 
 impl Decode for i128 {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
+        decoder.claim_bytes_read(16)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
                 crate::varint::varint_decode_i128(decoder.reader(), D::C::ENDIAN)
@@ -305,6 +316,7 @@ impl Decode for NonZeroI128 {
 
 impl Decode for isize {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
+        decoder.claim_bytes_read(8)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
                 crate::varint::varint_decode_isize(decoder.reader(), D::C::ENDIAN)
@@ -331,6 +343,7 @@ impl Decode for NonZeroIsize {
 
 impl Decode for f32 {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
+        decoder.claim_bytes_read(4)?;
         let mut bytes = [0u8; 4];
         decoder.reader().read(&mut bytes)?;
         Ok(match D::C::ENDIAN {
@@ -342,6 +355,7 @@ impl Decode for f32 {
 
 impl Decode for f64 {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
+        decoder.claim_bytes_read(8)?;
         let mut bytes = [0u8; 8];
         decoder.reader().read(&mut bytes)?;
         Ok(match D::C::ENDIAN {
@@ -362,6 +376,10 @@ impl Decode for char {
         if width == 0 {
             return Err(DecodeError::InvalidCharEncoding(array));
         }
+        // Normally we have to `.claim_bytes_read` before reading, however in this
+        // case the amount of bytes read from `char` can vary wildly, and it should
+        // only read up to 4 bytes too much.
+        decoder.claim_bytes_read(width)?;
         if width == 1 {
             return Ok(array[0] as char);
         }
@@ -379,6 +397,7 @@ impl Decode for char {
 impl<'a, 'de: 'a> BorrowDecode<'de> for &'a [u8] {
     fn borrow_decode<D: BorrowDecoder<'de>>(mut decoder: D) -> Result<Self, DecodeError> {
         let len = super::decode_slice_len(&mut decoder)?;
+        decoder.claim_bytes_read(len)?;
         decoder.borrow_reader().take_bytes(len)
     }
 }
@@ -397,7 +416,7 @@ impl<'a, 'de: 'a> BorrowDecode<'de> for Option<&'a [u8]> {
 
 impl<'a, 'de: 'a> BorrowDecode<'de> for &'a str {
     fn borrow_decode<D: BorrowDecoder<'de>>(decoder: D) -> Result<Self, DecodeError> {
-        let slice: &[u8] = BorrowDecode::borrow_decode(decoder)?;
+        let slice = <&[u8]>::borrow_decode(decoder)?;
         core::str::from_utf8(slice).map_err(DecodeError::Utf8)
     }
 }
@@ -429,6 +448,9 @@ where
             }
         }
 
+        decoder.claim_bytes_read(N * core::mem::size_of::<T>())?;
+
+        // Optimize for `[u8; N]`
         if TypeId::of::<u8>() == TypeId::of::<T>() {
             let mut buf = [0u8; N];
             decoder.reader().read(&mut buf)?;
@@ -439,8 +461,11 @@ where
             let res = unsafe { ptr.read() };
             Ok(res)
         } else {
-            let result =
-                super::impl_core::collect_into_array(&mut (0..N).map(|_| T::decode(&mut decoder)));
+            let result = super::impl_core::collect_into_array(&mut (0..N).map(|_| {
+                // See the documentation on `unclaim_bytes_read` as to why we're doing this here
+                decoder.unclaim_bytes_read(core::mem::size_of::<T>());
+                T::decode(&mut decoder)
+            }));
 
             // result is only None if N does not match the values of `(0..N)`, which it always should
             // So this unwrap should never occur

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -145,10 +145,12 @@ where
         T::config(self)
     }
 
+    #[inline]
     fn claim_bytes_read(&mut self, n: usize) -> Result<(), DecodeError> {
         T::claim_bytes_read(self, n)
     }
 
+    #[inline]
     fn unclaim_bytes_read(&mut self, n: usize) {
         T::unclaim_bytes_read(self, n)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -70,6 +70,9 @@ pub enum DecodeError {
     /// The reader reached its end but more bytes were expected.
     UnexpectedEnd,
 
+    /// The given configuration limit was exceeded
+    LimitExceeded,
+
     /// Invalid type was found. The decoder tried to read type `expected`, but found type `found` instead.
     InvalidIntegerType {
         /// The type that was being read from the reader

--- a/src/features/impl_alloc.rs
+++ b/src/features/impl_alloc.rs
@@ -52,8 +52,13 @@ where
 {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
         let len = crate::de::decode_slice_len(&mut decoder)?;
+        decoder.claim_bytes_read(len * core::mem::size_of::<T>())?;
+
         let mut map = BinaryHeap::with_capacity(len);
         for _ in 0..len {
+            // See the documentation on `unclaim_bytes_read` as to why we're doing this here
+            decoder.unclaim_bytes_read(core::mem::size_of::<T>());
+
             let key = T::decode(&mut decoder)?;
             map.push(key);
         }
@@ -81,8 +86,13 @@ where
 {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
         let len = crate::de::decode_slice_len(&mut decoder)?;
+        decoder.claim_bytes_read(len * (core::mem::size_of::<K>() + core::mem::size_of::<V>()))?;
+
         let mut map = BTreeMap::new();
         for _ in 0..len {
+            // See the documentation on `unclaim_bytes_read` as to why we're doing this here
+            decoder.unclaim_bytes_read(core::mem::size_of::<K>() + core::mem::size_of::<V>());
+
             let key = K::decode(&mut decoder)?;
             let value = V::decode(&mut decoder)?;
             map.insert(key, value);
@@ -112,8 +122,13 @@ where
 {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
         let len = crate::de::decode_slice_len(&mut decoder)?;
+        decoder.claim_bytes_read(len)?;
+
         let mut map = BTreeSet::new();
         for _ in 0..len {
+            // See the documentation on `unclaim_bytes_read` as to why we're doing this here
+            decoder.unclaim_bytes_read(core::mem::size_of::<T>());
+
             let key = T::decode(&mut decoder)?;
             map.insert(key);
         }
@@ -140,8 +155,13 @@ where
 {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
         let len = crate::de::decode_slice_len(&mut decoder)?;
+        decoder.claim_bytes_read(len)?;
+
         let mut map = VecDeque::with_capacity(len);
         for _ in 0..len {
+            // See the documentation on `unclaim_bytes_read` as to why we're doing this here
+            decoder.unclaim_bytes_read(core::mem::size_of::<T>());
+
             let key = T::decode(&mut decoder)?;
             map.push_back(key);
         }
@@ -168,8 +188,13 @@ where
 {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
         let len = crate::de::decode_slice_len(&mut decoder)?;
+        decoder.claim_bytes_read(len)?;
+
         let mut vec = Vec::with_capacity(len);
         for _ in 0..len {
+            // See the documentation on `unclaim_bytes_read` as to why we're doing this here
+            decoder.unclaim_bytes_read(core::mem::size_of::<T>());
+
             vec.push(T::decode(&mut decoder)?);
         }
         Ok(vec)

--- a/src/features/impl_alloc.rs
+++ b/src/features/impl_alloc.rs
@@ -52,7 +52,7 @@ where
 {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
         let len = crate::de::decode_slice_len(&mut decoder)?;
-        decoder.claim_bytes_read(len * core::mem::size_of::<T>())?;
+        decoder.claim_container_read::<T>(len)?;
 
         let mut map = BinaryHeap::with_capacity(len);
         for _ in 0..len {
@@ -86,12 +86,12 @@ where
 {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
         let len = crate::de::decode_slice_len(&mut decoder)?;
-        decoder.claim_bytes_read(len * (core::mem::size_of::<K>() + core::mem::size_of::<V>()))?;
+        decoder.claim_container_read::<(K, V)>(len)?;
 
         let mut map = BTreeMap::new();
         for _ in 0..len {
             // See the documentation on `unclaim_bytes_read` as to why we're doing this here
-            decoder.unclaim_bytes_read(core::mem::size_of::<K>() + core::mem::size_of::<V>());
+            decoder.unclaim_bytes_read(core::mem::size_of::<(K, V)>());
 
             let key = K::decode(&mut decoder)?;
             let value = V::decode(&mut decoder)?;
@@ -122,7 +122,7 @@ where
 {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
         let len = crate::de::decode_slice_len(&mut decoder)?;
-        decoder.claim_bytes_read(len)?;
+        decoder.claim_container_read::<T>(len)?;
 
         let mut map = BTreeSet::new();
         for _ in 0..len {
@@ -155,7 +155,7 @@ where
 {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
         let len = crate::de::decode_slice_len(&mut decoder)?;
-        decoder.claim_bytes_read(len)?;
+        decoder.claim_container_read::<T>(len)?;
 
         let mut map = VecDeque::with_capacity(len);
         for _ in 0..len {
@@ -188,7 +188,7 @@ where
 {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
         let len = crate::de::decode_slice_len(&mut decoder)?;
-        decoder.claim_bytes_read(len)?;
+        decoder.claim_container_read::<T>(len)?;
 
         let mut vec = Vec::with_capacity(len);
         for _ in 0..len {

--- a/src/features/impl_std.rs
+++ b/src/features/impl_std.rs
@@ -369,8 +369,13 @@ where
 {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
         let len = crate::de::decode_slice_len(&mut decoder)?;
+        decoder.claim_bytes_read(len * (core::mem::size_of::<K>() + core::mem::size_of::<V>()))?;
+
         let mut map = HashMap::with_capacity(len);
         for _ in 0..len {
+            // See the documentation on `unclaim_bytes_read` as to why we're doing this here
+            decoder.unclaim_bytes_read(core::mem::size_of::<K>() + core::mem::size_of::<V>());
+
             let k = K::decode(&mut decoder)?;
             let v = V::decode(&mut decoder)?;
             map.insert(k, v);

--- a/src/features/impl_std.rs
+++ b/src/features/impl_std.rs
@@ -369,12 +369,12 @@ where
 {
     fn decode<D: Decoder>(mut decoder: D) -> Result<Self, DecodeError> {
         let len = crate::de::decode_slice_len(&mut decoder)?;
-        decoder.claim_bytes_read(len * (core::mem::size_of::<K>() + core::mem::size_of::<V>()))?;
+        decoder.claim_container_read::<(K, V)>(len)?;
 
         let mut map = HashMap::with_capacity(len);
         for _ in 0..len {
             // See the documentation on `unclaim_bytes_read` as to why we're doing this here
-            decoder.unclaim_bytes_read(core::mem::size_of::<K>() + core::mem::size_of::<V>());
+            decoder.unclaim_bytes_read(core::mem::size_of::<(K, V)>());
 
             let k = K::decode(&mut decoder)?;
             let v = V::decode(&mut decoder)?;


### PR DESCRIPTION
Adds a limit to configuration and keeps track of how many bytes are going to be read, returning a `DecodeError::LimitExceeded` if this exceeds the amount of bytes read.

The reason this is set up like this is because we use a lot of `Container::with_capacity` when decoding containers. The limit exists primarily to not allocate too much value, for example when data is garbage, we don't want to accidentally allocate 10GB of memory when the data is invalid.

I've added an `unclaim` system as well. As per the `Decoder` comments:

> When decoding container types, a typical implementation would claim to read `len * size_of::<T>()` bytes.
> This is to ensure that bincode won't allocate several GB of memory while constructing the container.
> 
> Because the implementation claims `len * size_of::<T>()`, but then has to decode each `T`, this would be marked
> as double. This function allows us to un-claim each `T` that gets decoded.
> 
> We cannot check if `len * size_of::<T>()` is valid without claiming it, because this would mean that if you have
> a nested container (e.g. `Vec<Vec<T>>`), it does not know how much memory is already claimed, and could easily
> allocate much more than the user intends.
