### PR TITLE
[Breaking change] Made all `decode_from_slice` also return the number of bytes read

### DIFF
--- a/benches/varint.rs
+++ b/benches/varint.rs
@@ -14,7 +14,7 @@ fn slice_varint_u8(c: &mut Criterion) {
 
     c.bench_function("slice_varint_u8", |b| {
         b.iter(|| {
-            let _: Vec<u8> = bincode::decode_from_slice(&bytes, config).unwrap();
+            let _: (Vec<u8>, usize) = bincode::decode_from_slice(&bytes, config).unwrap();
         })
     });
 }
@@ -30,7 +30,7 @@ fn slice_varint_u16(c: &mut Criterion) {
 
     c.bench_function("slice_varint_u16", |b| {
         b.iter(|| {
-            let _: Vec<u16> = bincode::decode_from_slice(&bytes, config).unwrap();
+            let _: (Vec<u8>, usize) = bincode::decode_from_slice(&bytes, config).unwrap();
         })
     });
 }
@@ -46,7 +46,7 @@ fn slice_varint_u32(c: &mut Criterion) {
 
     c.bench_function("slice_varint_u32", |b| {
         b.iter(|| {
-            let _: Vec<u32> = bincode::decode_from_slice(&bytes, config).unwrap();
+            let _: (Vec<u16>, usize) = bincode::decode_from_slice(&bytes, config).unwrap();
         })
     });
 }
@@ -62,7 +62,7 @@ fn slice_varint_u64(c: &mut Criterion) {
 
     c.bench_function("slice_varint_u64", |b| {
         b.iter(|| {
-            let _: Vec<u64> = bincode::decode_from_slice(&bytes, config).unwrap();
+            let _: (Vec<u64>, usize) = bincode::decode_from_slice(&bytes, config).unwrap();
         })
     });
 }

--- a/derive/src/parse/generics.rs
+++ b/derive/src/parse/generics.rs
@@ -122,6 +122,7 @@ impl Generics {
 }
 
 #[derive(Debug)]
+#[allow(clippy::enum_variant_names)]
 enum Generic {
     Lifetime(Lifetime),
     Simple(SimpleGeneric),

--- a/readme.md
+++ b/readme.md
@@ -53,9 +53,10 @@ fn main() {
     // The 4 floats are encoded in 4 bytes each.
     assert_eq!(encoded.len(), 1 + 4 * 4);
 
-    let decoded: World = bincode::decode_from_slice(&encoded[..], config).unwrap();
+    let (decoded, len): (World, usize) = bincode::decode_from_slice(&encoded[..], config).unwrap();
 
     assert_eq!(world, decoded);
+    assert_eq!(len, encoded.len()); // read all bytes
 }
 ```
 

--- a/src/de/impl_core.rs
+++ b/src/de/impl_core.rs
@@ -1,4 +1,5 @@
 #![allow(unused_unsafe)]
+#![allow(clippy::needless_borrow)]
 
 //! Contains implementations for rust core that have not been stabilized
 //!

--- a/src/de/read.rs
+++ b/src/de/read.rs
@@ -61,7 +61,7 @@ pub trait BorrowReader<'storage>: Reader {
 
 /// A reader type for `&[u8]` slices. Implements both [Reader] and [BorrowReader], and thus can be used for borrowed data.
 pub struct SliceReader<'storage> {
-    slice: &'storage [u8],
+    pub(crate) slice: &'storage [u8],
 }
 
 impl<'storage> SliceReader<'storage> {

--- a/tests/alloc.rs
+++ b/tests/alloc.rs
@@ -44,9 +44,11 @@ fn test_vec() {
     let vec = bincode::encode_to_vec(Foo { a: 5, b: 10 }, Configuration::standard()).unwrap();
     assert_eq!(vec, &[5, 10]);
 
-    let foo: Foo = bincode::decode_from_slice(&vec, Configuration::standard()).unwrap();
+    let (foo, len): (Foo, usize) =
+        bincode::decode_from_slice(&vec, Configuration::standard()).unwrap();
     assert_eq!(foo.a, 5);
     assert_eq!(foo.b, 10);
+    assert_eq!(len, 2);
 }
 
 #[test]

--- a/tests/basic_types.rs
+++ b/tests/basic_types.rs
@@ -149,18 +149,20 @@ fn test_option_slice() {
     let n = bincode::encode_into_slice(input, &mut buffer, Configuration::standard()).unwrap();
     assert_eq!(&buffer[..n], &[1, 7, 1, 2, 3, 4, 5, 6, 7]);
 
-    let output: Option<&[u8]> =
+    let (output, len): (Option<&[u8]>, usize) =
         bincode::decode_from_slice(&buffer[..n], Configuration::standard()).unwrap();
     assert_eq!(input, output);
+    assert_eq!(len, n);
 
     let mut buffer = [0u8; 32];
     let input: Option<&[u8]> = None;
     let n = bincode::encode_into_slice(input, &mut buffer, Configuration::standard()).unwrap();
     assert_eq!(&buffer[..n], &[0]);
 
-    let output: Option<&[u8]> =
+    let (output, len): (Option<&[u8]>, usize) =
         bincode::decode_from_slice(&buffer[..n], Configuration::standard()).unwrap();
     assert_eq!(input, output);
+    assert_eq!(len, n);
 }
 
 #[test]
@@ -189,18 +191,20 @@ fn test_option_str() {
         &[1, 11, 72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]
     );
 
-    let output: Option<&str> =
+    let (output, len): (Option<&str>, usize) =
         bincode::decode_from_slice(&buffer[..n], Configuration::standard()).unwrap();
     assert_eq!(input, output);
+    assert_eq!(len, n);
 
     let mut buffer = [0u8; 32];
     let input: Option<&str> = None;
     let n = bincode::encode_into_slice(input, &mut buffer, Configuration::standard()).unwrap();
     assert_eq!(&buffer[..n], &[0]);
 
-    let output: Option<&str> =
+    let (output, len): (Option<&str>, usize) =
         bincode::decode_from_slice(&buffer[..n], Configuration::standard()).unwrap();
     assert_eq!(input, output);
+    assert_eq!(len, n);
 }
 
 #[test]

--- a/tests/basic_types.rs
+++ b/tests/basic_types.rs
@@ -136,9 +136,10 @@ fn test_slice() {
     bincode::encode_into_slice(input, &mut buffer, Configuration::standard()).unwrap();
     assert_eq!(&buffer[..8], &[7, 1, 2, 3, 4, 5, 6, 7]);
 
-    let output: &[u8] =
+    let (output, len): (&[u8], usize) =
         bincode::decode_from_slice(&mut buffer[..8], Configuration::standard()).unwrap();
     assert_eq!(input, output);
+    assert_eq!(len, 8);
 }
 
 #[test]
@@ -172,9 +173,10 @@ fn test_str() {
         &[11, 72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]
     );
 
-    let output: &str =
+    let (output, len): (&str, usize) =
         bincode::decode_from_slice(&mut buffer[..12], Configuration::standard()).unwrap();
     assert_eq!(input, output);
+    assert_eq!(len, 12);
 }
 
 #[test]
@@ -208,7 +210,8 @@ fn test_array() {
     bincode::encode_into_slice(input, &mut buffer, Configuration::standard()).unwrap();
     assert_eq!(&buffer[..10], &[10, 20, 30, 40, 50, 60, 70, 80, 90, 100]);
 
-    let output: [u8; 10] =
+    let (output, len): ([u8; 10], usize) =
         bincode::decode_from_slice(&mut buffer[..10], Configuration::standard()).unwrap();
     assert_eq!(input, output);
+    assert_eq!(len, 10);
 }

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -81,11 +81,11 @@ fn test_encode_decode_str() {
     let mut slice = [0u8; 100];
 
     let len = bincode::encode_into_slice(&start, &mut slice, Configuration::standard()).unwrap();
-    assert_eq!(len, 12);
+    assert_eq!(len, 21);
     let (end, len): (Test3, usize) =
         bincode::decode_from_slice(&slice[..len], Configuration::standard()).unwrap();
     assert_eq!(end, start);
-    assert_eq!(len, 12);
+    assert_eq!(len, 21);
 }
 
 #[test]

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -64,8 +64,10 @@ fn test_decode() {
         c: 1024u32,
     };
     let slice = [5, 10, 251, 0, 4];
-    let result: Test2<u32> = bincode::decode_from_slice(&slice, Configuration::standard()).unwrap();
+    let (result, len): (Test2<u32>, usize) =
+        bincode::decode_from_slice(&slice, Configuration::standard()).unwrap();
     assert_eq!(result, start);
+    assert_eq!(len, 5);
 }
 
 #[test]
@@ -79,8 +81,11 @@ fn test_encode_decode_str() {
     let mut slice = [0u8; 100];
 
     let len = bincode::encode_into_slice(&start, &mut slice, Configuration::standard()).unwrap();
-    let end: Test3 = bincode::decode_from_slice(&slice[..len], Configuration::standard()).unwrap();
+    assert_eq!(len, 12);
+    let (end, len): (Test3, usize) =
+        bincode::decode_from_slice(&slice[..len], Configuration::standard()).unwrap();
     assert_eq!(end, start);
+    assert_eq!(len, 12);
 }
 
 #[test]
@@ -97,9 +102,10 @@ fn test_encode_tuple() {
 fn test_decode_tuple() {
     let start = TestTupleStruct(5, 10, 1024);
     let mut slice = [5, 10, 251, 0, 4];
-    let result: TestTupleStruct =
+    let (result, len): (TestTupleStruct, usize) =
         bincode::decode_from_slice(&mut slice, Configuration::standard()).unwrap();
     assert_eq!(result, start);
+    assert_eq!(len, 5);
 }
 
 #[test]
@@ -116,9 +122,10 @@ fn test_encode_enum_struct_variant() {
 fn test_decode_enum_struct_variant() {
     let start = TestEnum::Bar { name: 5u32 };
     let mut slice = [1, 5];
-    let result: TestEnum =
+    let (result, len): (TestEnum, usize) =
         bincode::decode_from_slice(&mut slice, Configuration::standard()).unwrap();
     assert_eq!(result, start);
+    assert_eq!(len, 2);
 }
 
 #[test]
@@ -135,9 +142,10 @@ fn test_encode_enum_tuple_variant() {
 fn test_decode_enum_unit_variant() {
     let start = TestEnum::Foo;
     let mut slice = [0];
-    let result: TestEnum =
+    let (result, len): (TestEnum, usize) =
         bincode::decode_from_slice(&mut slice, Configuration::standard()).unwrap();
     assert_eq!(result, start);
+    assert_eq!(len, 1);
 }
 
 #[test]
@@ -154,9 +162,10 @@ fn test_encode_enum_unit_variant() {
 fn test_decode_enum_tuple_variant() {
     let start = TestEnum::Baz(5, 10, 1024);
     let mut slice = [2, 5, 10, 251, 0, 4];
-    let result: TestEnum =
+    let (result, len): (TestEnum, usize) =
         bincode::decode_from_slice(&mut slice, Configuration::standard()).unwrap();
     assert_eq!(result, start);
+    assert_eq!(len, 6);
 }
 
 #[derive(bincode::Decode, bincode::Encode, PartialEq, Eq, Debug)]
@@ -185,7 +194,9 @@ fn test_c_style_enum() {
     assert_eq!(ser(CStyleEnum::E), 6);
 
     fn de(num: u8) -> Result<CStyleEnum, bincode::error::DecodeError> {
-        bincode::decode_from_slice(&[num], Configuration::standard())
+        let (result, len) = bincode::decode_from_slice(&[num], Configuration::standard())?;
+        assert_eq!(len, 1);
+        Ok(result)
     }
 
     fn expected_err(idx: u32) -> Result<CStyleEnum, bincode::error::DecodeError> {

--- a/tests/issues/issue_431.rs
+++ b/tests/issues/issue_431.rs
@@ -26,7 +26,9 @@ fn test() {
     };
     let vec = bincode::encode_to_vec(&t, Configuration::standard()).unwrap();
 
-    let decoded: T<String> = bincode::decode_from_slice(&vec, Configuration::standard()).unwrap();
+    let (decoded, len): (T<String>, usize) =
+        bincode::decode_from_slice(&vec, Configuration::standard()).unwrap();
 
     assert_eq!(t, decoded);
+    assert_eq!(len, 12);
 }

--- a/tests/std.rs
+++ b/tests/std.rs
@@ -106,12 +106,16 @@ fn test_std_commons() {
     // &CStr
     let cstr = CStr::from_bytes_with_nul(b"Hello world\0").unwrap();
     let len = bincode::encode_into_slice(cstr, &mut buffer, config).unwrap();
-    let decoded: &CStr = bincode::decode_from_slice(&mut buffer[..len], config).unwrap();
+    let (decoded, len): (&CStr, usize) =
+        bincode::decode_from_slice(&mut buffer[..len], config).unwrap();
     assert_eq!(cstr, decoded);
+    assert_eq!(len, 13);
 
     // Path
     let path = Path::new("C:/Program Files/Foo");
     let len = bincode::encode_into_slice(path, &mut buffer, config).unwrap();
-    let decoded: &Path = bincode::decode_from_slice(&mut buffer[..len], config).unwrap();
+    let (decoded, len): (&Path, usize) =
+        bincode::decode_from_slice(&mut buffer[..len], config).unwrap();
     assert_eq!(path, decoded);
+    assert_eq!(len, 21);
 }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -15,7 +15,8 @@ where
         &buffer[..len],
         core::any::type_name::<C>()
     );
-    let decoded: V = bincode::decode_from_slice(&mut buffer, config).unwrap();
+    let (decoded, decoded_len): (V, usize) =
+        bincode::decode_from_slice(&mut buffer, config).unwrap();
 
     assert!(
         cmp(&element, &decoded),
@@ -24,6 +25,7 @@ where
         element,
         &buffer[..len],
     );
+    assert_eq!(len, decoded_len);
 }
 
 pub fn the_same_with_comparer<V, CMP>(element: V, cmp: CMP)


### PR DESCRIPTION
Currently there is no way to know how many bytes are read when decoding from a slice. This will make it harder to read multiple entries from a blob without encoding the length. This PR makes all `decode_from_slice` functions return the amount of bytes read. 

This is a breaking change, but we're still on alpha so this should be okay.

Also fixes some of the new clippy warnings. This will conflict with #443 but we'll fix that when we get there