### PR TITLE
Impl BorrowDecode for Option<&[u8]> and Option<&str>

### DIFF
--- a/src/de/impls.rs
+++ b/src/de/impls.rs
@@ -383,10 +383,34 @@ impl<'a, 'de: 'a> BorrowDecode<'de> for &'a [u8] {
     }
 }
 
+impl<'a, 'de: 'a> BorrowDecode<'de> for Option<&'a [u8]> {
+    fn borrow_decode<D: BorrowDecoder<'de>>(mut decoder: D) -> Result<Self, DecodeError> {
+        match super::decode_option_variant(&mut decoder, core::any::type_name::<Option<&[u8]>>())? {
+            Some(_) => {
+                let val = BorrowDecode::borrow_decode(decoder)?;
+                Ok(Some(val))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
 impl<'a, 'de: 'a> BorrowDecode<'de> for &'a str {
     fn borrow_decode<D: BorrowDecoder<'de>>(decoder: D) -> Result<Self, DecodeError> {
         let slice: &[u8] = BorrowDecode::borrow_decode(decoder)?;
         core::str::from_utf8(slice).map_err(DecodeError::Utf8)
+    }
+}
+
+impl<'a, 'de: 'a> BorrowDecode<'de> for Option<&'a str> {
+    fn borrow_decode<D: BorrowDecoder<'de>>(mut decoder: D) -> Result<Self, DecodeError> {
+        match super::decode_option_variant(&mut decoder, core::any::type_name::<Option<&str>>())? {
+            Some(_) => {
+                let val = BorrowDecode::borrow_decode(decoder)?;
+                Ok(Some(val))
+            }
+            None => Ok(None),
+        }
     }
 }
 

--- a/tests/basic_types.rs
+++ b/tests/basic_types.rs
@@ -142,6 +142,27 @@ fn test_slice() {
 }
 
 #[test]
+fn test_option_slice() {
+    let mut buffer = [0u8; 32];
+    let input: Option<&[u8]> = Some(&[1, 2, 3, 4, 5, 6, 7]);
+    let n = bincode::encode_into_slice(input, &mut buffer, Configuration::standard()).unwrap();
+    assert_eq!(&buffer[..n], &[1, 7, 1, 2, 3, 4, 5, 6, 7]);
+
+    let output: Option<&[u8]> =
+        bincode::decode_from_slice(&buffer[..n], Configuration::standard()).unwrap();
+    assert_eq!(input, output);
+
+    let mut buffer = [0u8; 32];
+    let input: Option<&[u8]> = None;
+    let n = bincode::encode_into_slice(input, &mut buffer, Configuration::standard()).unwrap();
+    assert_eq!(&buffer[..n], &[0]);
+
+    let output: Option<&[u8]> =
+        bincode::decode_from_slice(&buffer[..n], Configuration::standard()).unwrap();
+    assert_eq!(input, output);
+}
+
+#[test]
 fn test_str() {
     let mut buffer = [0u8; 32];
     let input: &str = "Hello world";
@@ -153,6 +174,30 @@ fn test_str() {
 
     let output: &str =
         bincode::decode_from_slice(&mut buffer[..12], Configuration::standard()).unwrap();
+    assert_eq!(input, output);
+}
+
+#[test]
+fn test_option_str() {
+    let mut buffer = [0u8; 32];
+    let input: Option<&str> = Some("Hello world");
+    let n = bincode::encode_into_slice(input, &mut buffer, Configuration::standard()).unwrap();
+    assert_eq!(
+        &buffer[..n],
+        &[1, 11, 72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]
+    );
+
+    let output: Option<&str> =
+        bincode::decode_from_slice(&buffer[..n], Configuration::standard()).unwrap();
+    assert_eq!(input, output);
+
+    let mut buffer = [0u8; 32];
+    let input: Option<&str> = None;
+    let n = bincode::encode_into_slice(input, &mut buffer, Configuration::standard()).unwrap();
+    assert_eq!(&buffer[..n], &[0]);
+
+    let output: Option<&str> =
+        bincode::decode_from_slice(&buffer[..n], Configuration::standard()).unwrap();
     assert_eq!(input, output);
 }
 

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -22,6 +22,7 @@ pub struct Test3<'a> {
     a: &'a str,
     b: u32,
     c: u32,
+    d: Option<&'a [u8]>,
 }
 
 #[derive(bincode::Encode, bincode::Decode, PartialEq, Debug, Eq)]
@@ -73,6 +74,7 @@ fn test_encode_decode_str() {
         a: "Foo bar",
         b: 10u32,
         c: 1024u32,
+        d: Some(b"Foo bar"),
     };
     let mut slice = [0u8; 100];
 


### PR DESCRIPTION
Since those two types are encodable, implements `BorrowDecode` for them is nature. 