### PR TITLE
[WIP] Deny OOM, embrace `try_reserve`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -128,32 +128,6 @@ fi",
         }
       ]
     },
-    "no_oom": {
-      "name": "Strict OOM checks",
-      "runs-on": "ubuntu-latest",
-      "steps": [
-        {
-          "uses": "actions/checkout@v2",
-          "name": "Checkout"
-        },
-        {
-          "uses": "actions-rs/toolchain@v1",
-          "with": {
-            "profile": "minimal",
-            "toolchain": "nightly",
-            "components": "rust-src",
-            "override": true
-          },
-          "name": "Install Rust nightly"
-        },
-        {
-          "run": "cargo build --no-default-features --features unstable-strict-oom-checks -Z build-std=core,alloc --target x86_64-unknown-linux-gnu",
-          "env": {
-            "RUSTFLAGS": "--cfg no_global_oom_handling"
-          }
-        }
-      ]
-    },
     "lints": {
       "name": "Lints",
       "runs-on": "ubuntu-latest",

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,7 @@
           "uses": "actions-rs/cargo@v1",
           "with": {
             "command": "check",
-            "args": "--all-features"
+            "args": "--features std,derive"
           },
           "name": "Run `cargo check`"
         },
@@ -128,6 +128,32 @@ fi",
         }
       ]
     },
+    "no_oom": {
+      "name": "Strict OOM checks",
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v2",
+          "name": "Checkout"
+        },
+        {
+          "uses": "actions-rs/toolchain@v1",
+          "with": {
+            "profile": "minimal",
+            "toolchain": "nightly",
+            "components": "rust-src",
+            "override": true
+          },
+          "name": "Install Rust nightly"
+        },
+        {
+          "run": "cargo build --no-default-features --features unstable-strict-oom-checks -Z build-std=core,alloc --target x86_64-unknown-linux-gnu",
+          "env": {
+            "RUSTFLAGS": "--cfg no_global_oom_handling"
+          }
+        }
+      ]
+    },
     "lints": {
       "name": "Lints",
       "runs-on": "ubuntu-latest",
@@ -158,7 +184,7 @@ fi",
           "uses": "actions-rs/cargo@v1",
           "with": {
             "command": "clippy",
-            "args": "--all-features -- -D warnings"
+            "args": "--features std,derive -- -D warnings"
           },
           "name": "Run `cargo clippy`"
         }
@@ -213,7 +239,7 @@ fi",
           "uses": "actions-rs/tarpaulin@v0.1",
           "with": {
             "version": "0.19.1",
-            "args": "--all --all-features"
+            "args": "--all --features std,derive"
           }
         },
         {

--- a/.github/workflows/strict_oom.yml
+++ b/.github/workflows/strict_oom.yml
@@ -1,0 +1,70 @@
+{
+  "name": "strict OOM",
+  "on": {
+    "push": {
+      "branches": [
+        "trunk",
+        "v*.x",
+        "ci/*"
+      ]
+    },
+    "pull_request": {
+      "branches": [
+        "trunk",
+        "v*.x"
+      ]
+    }
+  },
+  "jobs": {
+    "no_oom": {
+      "name": "Strict OOM checks",
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v2",
+          "name": "Checkout"
+        },
+        {
+          "uses": "actions-rs/toolchain@v1",
+          "with": {
+            "profile": "minimal",
+            "toolchain": "nightly",
+            "components": "rust-src",
+            "override": true
+          },
+          "name": "Install Rust nightly"
+        },
+        {
+          "run": "cargo build --no-default-features --features unstable-strict-oom-checks -Z build-std=core,alloc --target x86_64-unknown-linux-gnu",
+          "env": {
+            "RUSTFLAGS": "--cfg no_global_oom_handling"
+          }
+        }
+      ]
+    },
+    "miri": {
+      "name": "MIRI",
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v2",
+          "name": "Checkout"
+        },
+        {
+          "run": "rustup toolchain install nightly --component miri
+rustup override set nightly
+cargo miri setup",
+          "name": "Install Rust nightly"
+        },
+        {
+          "run": "cargo miri test",
+          "name": "Default features"
+        },
+        {
+          "run": "cargo miri test --no-default-features --features unstable-strict-oom-checks",
+          "name": "Strict OOM check"
+        }
+      ]
+    }
+  }
+}

--- a/.github/workflows/strict_oom.yml
+++ b/.github/workflows/strict_oom.yml
@@ -51,8 +51,8 @@
           "name": "Checkout"
         },
         {
-          "run": "rustup toolchain install nightly --component miri
-rustup override set nightly
+          "run": "rustup toolchain install nightly --component miri \n
+rustup override set nightly \n
 cargo miri setup",
           "name": "Install Rust nightly"
         },

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ std = ["alloc", "serde?/std"]
 alloc = ["serde?/alloc"]
 derive = ["bincode_derive"]
 
+# experimental strict OOM checks, requires nightly features
+unstable-strict-oom-checks = ["alloc"]
+
 [dependencies]
 bincode_derive = { path = "derive", version = "2.0.0-rc.3", optional = true }
 serde = { version = "1.0", default-features = false, optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -214,12 +214,14 @@ pub enum OutOfMemory {
     Alloc(AllocError),
 }
 
+#[cfg(feature = "alloc")]
 impl From<TryReserveError> for DecodeError {
     fn from(e: TryReserveError) -> Self {
         Self::OutOfMemory(OutOfMemory::TryReserve(e))
     }
 }
 
+#[cfg(feature = "alloc")]
 impl From<TryReserveError> for EncodeError {
     fn from(e: TryReserveError) -> Self {
         Self::OutOfMemory(OutOfMemory::TryReserve(e))
@@ -235,13 +237,6 @@ impl From<AllocError> for DecodeError {
 
 #[cfg(all(feature = "alloc", feature = "unstable-strict-oom-checks"))]
 impl From<AllocError> for EncodeError {
-    fn from(e: AllocError) -> Self {
-        Self::OutOfMemory(OutOfMemory::Alloc(e))
-    }
-}
-
-#[cfg(all(feature = "alloc", feature = "unstable-strict-oom-checks"))]
-impl From<AllocError> for DecodeError {
     fn from(e: AllocError) -> Self {
         Self::OutOfMemory(OutOfMemory::Alloc(e))
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -205,7 +205,7 @@ pub enum DecodeError {
 
 /// A wrapper to make all the out of memory errors consistent
 #[cfg(feature = "alloc")]
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum OutOfMemory {
     /// Failed to reserve an entry
     TryReserve(TryReserveError),

--- a/src/features/impl_alloc.rs
+++ b/src/features/impl_alloc.rs
@@ -266,7 +266,7 @@ where
         if unty::type_equal::<T, u8>() {
             decoder.claim_container_read::<T>(len)?;
             // optimize for reading u8 vecs
-            let mut vec = alloc::vec![0u8; len];
+            let mut vec = alloc::vec::from_elem(0u8, len);
             decoder.reader().read(&mut vec)?;
             // Safety: Vec<T> is Vec<u8>
             Ok(unsafe { core::mem::transmute(vec) })
@@ -630,6 +630,7 @@ where
     }
 }
 
+#[cfg(not(feature = "unstable-strict-oom-checks"))]
 /// A drop guard that will trigger when an item fails to decode.
 /// If an item at index n fails to decode, we have to properly drop the 0..(n-1) values that have been read.
 struct DropGuard<'a, T> {
@@ -637,6 +638,7 @@ struct DropGuard<'a, T> {
     idx: usize,
 }
 
+#[cfg(not(feature = "unstable-strict-oom-checks"))]
 impl<'a, T> Drop for DropGuard<'a, T> {
     fn drop(&mut self) {
         unsafe {

--- a/src/features/impl_alloc.rs
+++ b/src/features/impl_alloc.rs
@@ -420,7 +420,7 @@ where
     T: Decode + 'static,
 {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
-        let len = decode_slice_len(decoder)?;
+        let len = crate::de::decode_slice_len(decoder)?;
         decoder.claim_container_read::<T>(len)?;
 
         unsafe {

--- a/src/features/impl_std.rs
+++ b/src/features/impl_std.rs
@@ -432,7 +432,9 @@ where
         decoder.claim_container_read::<(K, V)>(len)?;
 
         let hash_builder: S = Default::default();
-        let mut map = HashMap::with_capacity_and_hasher(len, hash_builder);
+        let mut map = HashMap::with_hasher(hash_builder);
+        map.try_reserve(len)?;
+
         for _ in 0..len {
             // See the documentation on `unclaim_bytes_read` as to why we're doing this here
             decoder.unclaim_bytes_read(core::mem::size_of::<(K, V)>());
@@ -454,8 +456,9 @@ where
         let len = crate::de::decode_slice_len(decoder)?;
         decoder.claim_container_read::<(K, V)>(len)?;
 
-        let hash_builder: S = Default::default();
-        let mut map = HashMap::with_capacity_and_hasher(len, hash_builder);
+        let mut map = HashMap::with_hasher(S::default());
+        map.try_reserve(len)?;
+
         for _ in 0..len {
             // See the documentation on `unclaim_bytes_read` as to why we're doing this here
             decoder.unclaim_bytes_read(core::mem::size_of::<(K, V)>());

--- a/src/features/serde/de_borrowed.rs
+++ b/src/features/serde/de_borrowed.rs
@@ -442,7 +442,7 @@ impl<'de, 'a, DE: BorrowDecoder<'de>> EnumAccess<'de> for SerdeDecoder<'a, 'de, 
         V: DeserializeSeed<'de>,
     {
         let idx = u32::decode(&mut self.de)?;
-        let val = seed.deserialize(idx.into_deserializer())?;
+        let val = seed.deserialize(serde::de::value::U32Deserializer::<Self::Error>::new(idx))?;
         Ok((val, self))
     }
 }

--- a/src/features/serde/de_owned.rs
+++ b/src/features/serde/de_owned.rs
@@ -447,7 +447,7 @@ impl<'de, 'a, DE: Decoder> EnumAccess<'de> for SerdeDecoder<'a, DE> {
         V: DeserializeSeed<'de>,
     {
         let idx = u32::decode(&mut self.de)?;
-        let val = seed.deserialize(idx.into_deserializer())?;
+        let val = seed.deserialize(serde::de::value::U32Deserializer::<Self::Error>::new(idx))?;
         Ok((val, self))
     }
 }

--- a/src/features/serde/mod.rs
+++ b/src/features/serde/mod.rs
@@ -139,10 +139,9 @@ pub enum EncodeError {
     CustomError,
 }
 
-#[allow(clippy::from_over_into)]
-impl Into<crate::error::EncodeError> for EncodeError {
-    fn into(self) -> crate::error::EncodeError {
-        crate::error::EncodeError::Serde(self)
+impl From<EncodeError> for crate::error::EncodeError {
+    fn from(val: EncodeError) -> Self {
+        crate::error::EncodeError::Serde(val)
     }
 }
 

--- a/src/features/serde/ser.rs
+++ b/src/features/serde/ser.rs
@@ -218,7 +218,7 @@ where
     }
 
     fn serialize_seq(mut self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        let len = len.ok_or_else(|| SerdeEncodeError::SequenceMustHaveLength.into())?;
+        let len = len.ok_or(EncodeError::Serde(SerdeEncodeError::SequenceMustHaveLength))?;
         len.encode(&mut self.enc)?;
         Ok(Compound { enc: self.enc })
     }
@@ -247,7 +247,7 @@ where
     }
 
     fn serialize_map(mut self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
-        let len = len.ok_or_else(|| SerdeEncodeError::SequenceMustHaveLength.into())?;
+        let len = len.ok_or(EncodeError::Serde(SerdeEncodeError::SequenceMustHaveLength))?;
         len.encode(&mut self.enc)?;
         Ok(Compound { enc: self.enc })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
 #![no_std]
 #![warn(missing_docs, unused_lifetimes)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(
+    feature = "unstable-strict-oom-checks",
+    feature(allocator_api, new_uninit)
+)]
 
 //! Bincode is a crate for encoding and decoding using a tiny binary
 //! serialization strategy.  Using it, you can easily go from having

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,13 +19,14 @@
 //!
 //! # Features
 //!
-//! |Name  |Default?|Supported types for Encode/Decode|Enabled methods                                                  |Other|
-//! |------|--------|-----------------------------------------|-----------------------------------------------------------------|-----|
-//! |std   | Yes    |`HashMap` and `HashSet`|`decode_from_std_read` and `encode_into_std_write`|
-//! |alloc | Yes    |All common containers in alloc, like `Vec`, `String`, `Box`|`encode_to_vec`|
-//! |atomic| Yes    |All `Atomic*` integer types, e.g. `AtomicUsize`, and `AtomicBool`||
-//! |derive| Yes    |||Enables the `BorrowDecode`, `Decode` and `Encode` derive macros|
-//! |serde | No     |`Compat` and `BorrowCompat`, which will work for all types that implement serde's traits|serde-specific encode/decode functions in the [serde] module|Note: There are several [known issues](serde/index.html#known-issues) when using serde and bincode|
+//! |Name                      |Default?|Supported types for Encode/Decode|Enabled methods                                                  |Other|
+//! |--------------------------|--------|-----------------------------------------|-----------------------------------------------------------------|-----|
+//! |std                       | Yes    |`HashMap` and `HashSet`|`decode_from_std_read` and `encode_into_std_write`|
+//! |alloc                     | Yes    |All common containers in alloc, like `Vec`, `String`, `Box`|`encode_to_vec`|
+//! |atomic                    | Yes    |All `Atomic*` integer types, e.g. `AtomicUsize`, and `AtomicBool`||
+//! |derive                    | Yes    |||Enables the `BorrowDecode`, `Decode` and `Encode` derive macros|
+//! |serde                     | No     |`Compat` and `BorrowCompat`, which will work for all types that implement serde's traits|serde-specific encode/decode functions in the [serde] module|Note: There are several [known issues](serde/index.html#known-issues) when using serde and bincode|
+//! |unstable-strict-oom-checks| No     |||Enabled strict OOM checks which ensures that bincode will never cause OOM issues.<br>This requires nightly feature so you need to use a nightly compiler.<br>This may break or be changed at any point in the future|
 //!
 //! # Which functions to use
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,13 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(
     feature = "unstable-strict-oom-checks",
-    feature(allocator_api, new_uninit)
+    feature(
+        allocator_api,
+        new_uninit,
+        maybe_uninit_write_slice,
+        vec_push_within_capacity,
+        try_with_capacity
+    )
 )]
 
 //! Bincode is a crate for encoding and decoding using a tiny binary

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,6 @@ pub mod de;
 pub mod enc;
 pub mod error;
 
-pub use atomic::*;
 pub use de::{BorrowDecode, Decode};
 pub use enc::Encode;
 

--- a/src/varint/decode_unsigned.rs
+++ b/src/varint/decode_unsigned.rs
@@ -1,11 +1,10 @@
-use core::{convert::TryInto, u32};
-
 use super::{SINGLE_BYTE_MAX, U128_BYTE, U16_BYTE, U32_BYTE, U64_BYTE};
 use crate::{
     config::Endianness,
     de::read::Reader,
     error::{DecodeError, IntegerType},
 };
+use core::u32;
 
 #[inline(never)]
 #[cold]

--- a/tests/basic_types.rs
+++ b/tests/basic_types.rs
@@ -25,7 +25,6 @@ fn test_numbers() {
     the_same(5i128);
     the_same(5isize);
 
-    println!("Test {:?}", 5.0f32);
     the_same_with_comparer(5.0f32, |a, b| (a - b).abs() <= f32::EPSILON);
     the_same_with_comparer(5.0f64, |a, b| (a - b).abs() <= f64::EPSILON);
 

--- a/tests/std.rs
+++ b/tests/std.rs
@@ -51,13 +51,10 @@ fn test_std_cursor() {
     assert_eq!(foo.b, 10);
 }
 
+#[cfg(not(feature = "unstable-strict-oom-checks"))]
 #[test]
 fn test_std_file() {
-    #[cfg_attr(miri, ignore)]
-    fn create_temp_file() -> std::fs::File {
-        tempfile::tempfile().expect("Could not create temp file")
-    }
-    let mut file = create_temp_file();
+    let mut file = tempfile::tempfile().expect("Could not create temp file");
 
     let bytes_written = bincode::encode_into_std_write(
         Foo { a: 30, b: 50 },

--- a/tests/std.rs
+++ b/tests/std.rs
@@ -53,7 +53,11 @@ fn test_std_cursor() {
 
 #[test]
 fn test_std_file() {
-    let mut file = tempfile::tempfile().expect("Could not create temp file");
+    #[cfg_attr(miri, ignore)]
+    fn create_temp_file() -> std::fs::File {
+        tempfile::tempfile().expect("Could not create temp file")
+    }
+    let mut file = create_temp_file();
 
     let bytes_written = bincode::encode_into_std_write(
         Foo { a: 30, b: 50 },

--- a/tests/std.rs
+++ b/tests/std.rs
@@ -51,7 +51,8 @@ fn test_std_cursor() {
     assert_eq!(foo.b, 10);
 }
 
-#[cfg(not(feature = "unstable-strict-oom-checks"))]
+// miri seems to not be able to deal with `tempfile::tempfile()`
+#[cfg_attr(miri, ignore)]
 #[test]
 fn test_std_file() {
     let mut file = tempfile::tempfile().expect("Could not create temp file");


### PR DESCRIPTION
With [Rust 1.57](https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html#fallible-allocation), several `try_reserve` methods have been stabilized. This PR makes bincode take advantage of this.

A nightly flag can be set to disable all fallible allocations. This is currently blocked on the following features:
- [ ] `allocator_api` [tracking issue](https://github.com/rust-lang/wg-allocators/issues/48)
  - [ ] [Arc::try_new](https://doc.rust-lang.org/stable/std/sync/struct.Arc.html#method.try_new)
  - [ ] [Rc::try_new](https://doc.rust-lang.org/stable/std/rc/struct.Rc.html#method.try_new)
  - [ ] [Box::try_new_uninit_slice](https://doc.rust-lang.org/stable/std/boxed/struct.Box.html#method.try_new_uninit_slice)
  - [ ] [AllocError](https://doc.rust-lang.org/stable/std/alloc/struct.AllocError.html)
- [ ] `new_uninit` [tracking issue](https://github.com/rust-lang/rust/issues/63291)
- [x] `try_reserve` on more collections: [tracking issue](https://github.com/rust-lang/rust/issues/91789)

And uses the following features, although this could be implemented manually:
- [ ] `maybe_uninit_slice` [tracking issue](https://github.com/rust-lang/rust/issues/63569)
- [x] `vec_spare_capacity` [tracking issue](https://github.com/rust-lang/rust/issues/75017) (stabilized on jan 18, 2022)

Other useful issues:
- [ ] `Vec::push_within_capacity` to reduce the amount of unsafe code to replace `Vec::push` [tracking issue](https://github.com/rust-lang/rust/issues/100486)