### PR TITLE
Made the derive macros automatically implement the required traits on generic arguments

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -16,4 +16,4 @@ description = "Implementation of #[derive(Encode, Decode)] for bincode"
 proc-macro = true
 
 [dependencies]
-virtue = "0.0.2" 
+virtue = "0.0.3" 

--- a/derive/src/derive_enum.rs
+++ b/derive/src/derive_enum.rs
@@ -21,6 +21,11 @@ impl DeriveEnum {
     pub fn generate_encode(self, generator: &mut Generator) -> Result<()> {
         generator
             .impl_for("bincode::enc::Encode")?
+            .modify_generic_constraints(|generics, where_constraints| {
+                for g in generics.iter_generics() {
+                    where_constraints.push_constraint(g, "bincode::enc::Encode").unwrap();
+                }
+            })
             .generate_fn("encode")
             .with_generic("E", ["bincode::enc::Encoder"])
             .with_self_arg(FnSelfArg::RefSelf)
@@ -180,6 +185,11 @@ impl DeriveEnum {
 
         generator
             .impl_for("bincode::Decode")?
+            .modify_generic_constraints(|generics, where_constraints| {
+                for g in generics.iter_generics() {
+                    where_constraints.push_constraint(g, "bincode::enc::Decode").unwrap();
+                }
+            })
             .generate_fn("decode")
             .with_generic("D", ["bincode::de::Decoder"])
             .with_arg("mut decoder", "D")
@@ -247,6 +257,11 @@ impl DeriveEnum {
         let enum_name = generator.target_name().to_string();
 
         generator.impl_for_with_lifetimes("bincode::de::BorrowDecode", &["__de"])?
+            .modify_generic_constraints(|generics, where_constraints| {
+                for g in generics.iter_generics() {
+                    where_constraints.push_constraint(g, "bincode::enc::BorrowDecode").unwrap();
+                }
+            })
             .generate_fn("borrow_decode")
             .with_generic("D", ["bincode::de::BorrowDecoder<'__de>"])
             .with_arg("mut decoder", "D")

--- a/derive/src/derive_struct.rs
+++ b/derive/src/derive_struct.rs
@@ -12,8 +12,12 @@ impl DeriveStruct {
         let DeriveStruct { fields } = self;
 
         generator
-            .impl_for("bincode::enc::Encode")
-            .unwrap()
+            .impl_for("bincode::enc::Encode")?
+            .modify_generic_constraints(|generics, where_constraints| {
+                for g in generics.iter_generics() {
+                    where_constraints.push_constraint(g, "bincode::enc::Encode").unwrap();
+                }
+            })
             .generate_fn("encode")
             .with_generic("E", ["bincode::enc::Encoder"])
             .with_self_arg(virtue::generate::FnSelfArg::RefSelf)
@@ -46,8 +50,12 @@ impl DeriveStruct {
         let DeriveStruct { fields } = self;
 
         generator
-            .impl_for("bincode::Decode")
-            .unwrap()
+            .impl_for("bincode::Decode")?
+            .modify_generic_constraints(|generics, where_constraints| {
+                for g in generics.iter_generics() {
+                    where_constraints.push_constraint(g, "bincode::de::Decode").unwrap();
+                }
+            })
             .generate_fn("decode")
             .with_generic("D", ["bincode::de::Decoder"])
             .with_arg("mut decoder", "D")
@@ -93,8 +101,12 @@ impl DeriveStruct {
         let DeriveStruct { fields } = self;
 
         generator
-            .impl_for_with_lifetimes("bincode::de::BorrowDecode", &["__de"])
-            .unwrap()
+            .impl_for_with_lifetimes("bincode::de::BorrowDecode", &["__de"])?
+            .modify_generic_constraints(|generics, where_constraints| {
+                for g in generics.iter_generics() {
+                    where_constraints.push_constraint(g, "bincode::de::BorrowDecode").unwrap();
+                }
+            })
             .generate_fn("borrow_decode")
             .with_generic("D", ["bincode::de::BorrowDecoder<'__de>"])
             .with_arg("mut decoder", "D")

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -1,17 +1,15 @@
 #![cfg(feature = "derive")]
 
 use bincode::config::Configuration;
-use bincode::{de::Decode, enc::Encode};
-
 #[derive(bincode::Encode, PartialEq, Debug)]
-pub(crate) struct Test<T: Encode> {
+pub(crate) struct Test<T> {
     a: T,
     b: u32,
     c: u8,
 }
 
 #[derive(bincode::Decode, PartialEq, Debug, Eq)]
-pub struct Test2<T: Decode> {
+pub struct Test2<T> {
     a: T,
     b: u32,
     c: u32,


### PR DESCRIPTION
Fixed #451 

This PR builds upon a new function in `virtue`: [`modify_generic_constraints`](https://docs.rs/virtue/latest/virtue/generate/struct.ImplFor.html#method.modify_generic_constraints)

The derive macros will now automatically assume any generic argument implements the required traits.

If a user is in a situation where this isn't required, a solution is:
- They can implement the `BorrowDecode`/`Decode`/`Encode` manually
- We can add a `#[bincode(bounds = "T: Decode")]` attribute in the future to override the current type check logic, similar to https://serde.rs/container-attrs.html#bound