### PR TITLE
Fixed derive impl on an empty enum

### DIFF
--- a/derive/src/derive_enum.rs
+++ b/derive/src/derive_enum.rs
@@ -36,7 +36,7 @@ impl DeriveEnum {
                 fn_body.ident_str("self");
                 fn_body.group(Delimiter::Brace, |match_body| {
                     if self.variants.is_empty() {
-                        self.add_empty_variant_case(match_body)?;
+                        self.encode_empty_enum_case(match_body)?;
                     }
                     for (variant_index, variant) in self.iter_fields() {
                         // Self::Variant
@@ -118,7 +118,7 @@ impl DeriveEnum {
 
     /// If we're encoding an empty enum, we need to add an empty case in the form of:
     /// `_ => core::unreachable!(),`
-    fn add_empty_variant_case(&self, builder: &mut StreamBuilder) -> Result {
+    fn encode_empty_enum_case(&self, builder: &mut StreamBuilder) -> Result {
         builder.push_parsed("_ => core::unreachable!()").map(|_| ())
     }
 
@@ -177,7 +177,7 @@ impl DeriveEnum {
                     // no fixed values, implement a range
                     variant_inner.push_parsed(format!(
                         "bincode::error::AllowedEnumVariants::Range {{ min: 0, max: {} }}",
-                        self.variants.len().saturating_sub(1)
+                        self.variants.len() - 1
                     ))?;
                 }
                 Ok(())
@@ -204,57 +204,61 @@ impl DeriveEnum {
             .with_arg("mut decoder", "D")
             .with_return_type("core::result::Result<Self, bincode::error::DecodeError>")
             .body(|fn_builder| {
-                fn_builder
-                    .push_parsed(
-                        "let variant_index = <u32 as bincode::Decode>::decode(&mut decoder)?;",
-                    )?;
-                fn_builder.push_parsed("match variant_index")?;
-                fn_builder.group(Delimiter::Brace, |variant_case| {
-                    for (mut variant_index, variant) in self.iter_fields() {
-                        // idx => Ok(..)
-                        if variant_index.len() > 1 {
-                            variant_case.push_parsed("x if x == ")?;
-                            variant_case.extend(variant_index);
-                        } else {
-                            variant_case.push(variant_index.remove(0));
-                        }
-                        variant_case.puncts("=>");
-                        variant_case.ident_str("Ok");
-                        variant_case.group(Delimiter::Parenthesis, |variant_case_body| {
-                            // Self::Variant { }
-                            // Self::Variant { 0: ..., 1: ... 2: ... },
-                            // Self::Variant { a: ..., b: ... c: ... },
-                            variant_case_body.ident_str("Self");
-                            variant_case_body.puncts("::");
-                            variant_case_body.ident(variant.name.clone());
+                if self.variants.is_empty() {
+                    fn_builder.push_parsed("core::result::Result::Err(bincode::error::DecodeError::EmptyEnum { type_name: core::any::type_name::<Self>() })")?;
+                } else {
+                    fn_builder
+                        .push_parsed(
+                            "let variant_index = <u32 as bincode::Decode>::decode(&mut decoder)?;",
+                        )?;
+                    fn_builder.push_parsed("match variant_index")?;
+                    fn_builder.group(Delimiter::Brace, |variant_case| {
+                        for (mut variant_index, variant) in self.iter_fields() {
+                            // idx => Ok(..)
+                            if variant_index.len() > 1 {
+                                variant_case.push_parsed("x if x == ")?;
+                                variant_case.extend(variant_index);
+                            } else {
+                                variant_case.push(variant_index.remove(0));
+                            }
+                            variant_case.puncts("=>");
+                            variant_case.ident_str("Ok");
+                            variant_case.group(Delimiter::Parenthesis, |variant_case_body| {
+                                // Self::Variant { }
+                                // Self::Variant { 0: ..., 1: ... 2: ... },
+                                // Self::Variant { a: ..., b: ... c: ... },
+                                variant_case_body.ident_str("Self");
+                                variant_case_body.puncts("::");
+                                variant_case_body.ident(variant.name.clone());
 
-                            variant_case_body.group(Delimiter::Brace, |variant_body| {
-                                let is_tuple = matches!(variant.fields, Fields::Tuple(_));
-                                for (idx, field) in variant.fields.names().into_iter().enumerate() {
-                                    if is_tuple {
-                                        variant_body.lit_usize(idx);
-                                    } else {
-                                        variant_body.ident(field.unwrap_ident().clone());
+                                variant_case_body.group(Delimiter::Brace, |variant_body| {
+                                    let is_tuple = matches!(variant.fields, Fields::Tuple(_));
+                                    for (idx, field) in variant.fields.names().into_iter().enumerate() {
+                                        if is_tuple {
+                                            variant_body.lit_usize(idx);
+                                        } else {
+                                            variant_body.ident(field.unwrap_ident().clone());
+                                        }
+                                        variant_body.punct(':');
+                                        if field.attributes().has_attribute(FieldAttribute::WithSerde)? {
+                                            variant_body
+                                                .push_parsed("<bincode::serde::Compat<_> as bincode::Decode>::decode(&mut decoder)?.0,")?;
+                                        } else {
+                                            variant_body
+                                                .push_parsed("bincode::Decode::decode(&mut decoder)?,")?;
+                                        }
                                     }
-                                    variant_body.punct(':');
-                                    if field.attributes().has_attribute(FieldAttribute::WithSerde)? {
-                                        variant_body
-                                            .push_parsed("<bincode::serde::Compat<_> as bincode::Decode>::decode(&mut decoder)?.0,")?;
-                                    } else {
-                                        variant_body
-                                            .push_parsed("bincode::Decode::decode(&mut decoder)?,")?;
-                                    }
-                                }
+                                    Ok(())
+                                })?;
                                 Ok(())
                             })?;
-                            Ok(())
-                        })?;
-                        variant_case.punct(',');
-                    }
+                            variant_case.punct(',');
+                        }
 
-                    // invalid idx
-                    self.invalid_variant_case(&enum_name, variant_case)
-                })?;
+                        // invalid idx
+                        self.invalid_variant_case(&enum_name, variant_case)
+                    })?;
+                }
                 Ok(())
             })?;
         Ok(())
@@ -276,54 +280,58 @@ impl DeriveEnum {
             .with_arg("mut decoder", "D")
             .with_return_type("core::result::Result<Self, bincode::error::DecodeError>")
             .body(|fn_builder| {
-                fn_builder
-                    .push_parsed("let variant_index = <u32 as bincode::Decode>::decode(&mut decoder)?;")?;
-                fn_builder.push_parsed("match variant_index")?;
-                fn_builder.group(Delimiter::Brace, |variant_case| {
-                    for (mut variant_index, variant) in self.iter_fields() {
-                        // idx => Ok(..)
-                        if variant_index.len() > 1 {
-                            variant_case.push_parsed("x if x == ")?;
-                            variant_case.extend(variant_index);
-                        } else {
-                            variant_case.push(variant_index.remove(0));
-                        }
-                        variant_case.puncts("=>");
-                        variant_case.ident_str("Ok");
-                        variant_case.group(Delimiter::Parenthesis, |variant_case_body| {
-                            // Self::Variant { }
-                            // Self::Variant { 0: ..., 1: ... 2: ... },
-                            // Self::Variant { a: ..., b: ... c: ... },
-                            variant_case_body.ident_str("Self");
-                            variant_case_body.puncts("::");
-                            variant_case_body.ident(variant.name.clone());
+                if self.variants.is_empty() {
+                    fn_builder.push_parsed("core::result::Result::Err(bincode::error::DecodeError::EmptyEnum { type_name: core::any::type_name::<Self>() })")?;
+                } else {
+                    fn_builder
+                        .push_parsed("let variant_index = <u32 as bincode::Decode>::decode(&mut decoder)?;")?;
+                    fn_builder.push_parsed("match variant_index")?;
+                    fn_builder.group(Delimiter::Brace, |variant_case| {
+                        for (mut variant_index, variant) in self.iter_fields() {
+                            // idx => Ok(..)
+                            if variant_index.len() > 1 {
+                                variant_case.push_parsed("x if x == ")?;
+                                variant_case.extend(variant_index);
+                            } else {
+                                variant_case.push(variant_index.remove(0));
+                            }
+                            variant_case.puncts("=>");
+                            variant_case.ident_str("Ok");
+                            variant_case.group(Delimiter::Parenthesis, |variant_case_body| {
+                                // Self::Variant { }
+                                // Self::Variant { 0: ..., 1: ... 2: ... },
+                                // Self::Variant { a: ..., b: ... c: ... },
+                                variant_case_body.ident_str("Self");
+                                variant_case_body.puncts("::");
+                                variant_case_body.ident(variant.name.clone());
 
-                            variant_case_body.group(Delimiter::Brace, |variant_body| {
-                                let is_tuple = matches!(variant.fields, Fields::Tuple(_));
-                                for (idx, field) in variant.fields.names().into_iter().enumerate() {
-                                    if is_tuple {
-                                        variant_body.lit_usize(idx);
-                                    } else {
-                                        variant_body.ident(field.unwrap_ident().clone());
+                                variant_case_body.group(Delimiter::Brace, |variant_body| {
+                                    let is_tuple = matches!(variant.fields, Fields::Tuple(_));
+                                    for (idx, field) in variant.fields.names().into_iter().enumerate() {
+                                        if is_tuple {
+                                            variant_body.lit_usize(idx);
+                                        } else {
+                                            variant_body.ident(field.unwrap_ident().clone());
+                                        }
+                                        variant_body.punct(':');
+                                        if field.attributes().has_attribute(FieldAttribute::WithSerde)? {
+                                            variant_body
+                                                .push_parsed("<bincode::serde::BorrowCompat<_> as bincode::BorrowDecode>::borrow_decode(&mut decoder)?.0,")?;
+                                        } else {
+                                            variant_body.push_parsed("bincode::de::BorrowDecode::borrow_decode(&mut decoder)?,")?;
+                                        }
                                     }
-                                    variant_body.punct(':');
-                                    if field.attributes().has_attribute(FieldAttribute::WithSerde)? {
-                                        variant_body
-                                            .push_parsed("<bincode::serde::BorrowCompat<_> as bincode::BorrowDecode>::borrow_decode(&mut decoder)?.0,")?;
-                                    } else {
-                                        variant_body.push_parsed("bincode::de::BorrowDecode::borrow_decode(&mut decoder)?,")?;
-                                    }
-                                }
+                                    Ok(())
+                                })?;
                                 Ok(())
                             })?;
-                            Ok(())
-                        })?;
-                        variant_case.punct(',');
-                    }
+                            variant_case.punct(',');
+                        }
 
-                    // invalid idx
-                    self.invalid_variant_case(&enum_name, variant_case)
-                })?;
+                        // invalid idx
+                        self.invalid_variant_case(&enum_name, variant_case)
+                    })?;
+                }
                 Ok(())
             })?;
         Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -116,6 +116,12 @@ pub enum DecodeError {
         found: usize,
     },
 
+    /// Tried to decode an enum with no variants
+    EmptyEnum {
+        /// The type that was being decoded
+        type_name: &'static str,
+    },
+
     /// The decoder tried to decode a `CStr` or `CString`, but the incoming data contained a 0 byte
     #[cfg(feature = "std")]
     CStrNulError {

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -252,8 +252,20 @@ fn test_macro_newtype() {
     }
 }
 
-#[derive(bincode::Encode, bincode::Decode)]
+#[derive(bincode::Encode, bincode::Decode, Debug)]
 pub enum EmptyEnum {}
 
-#[derive(bincode::Encode, bincode::BorrowDecode)]
+#[derive(bincode::Encode, bincode::BorrowDecode, Debug)]
 pub enum BorrowedEmptyEnum {}
+
+#[test]
+fn test_empty_enum_decode() {
+    let err =
+        bincode::decode_from_slice::<EmptyEnum, _>(&[], Configuration::standard()).unwrap_err();
+    assert_eq!(
+        err,
+        bincode::error::DecodeError::EmptyEnum {
+            type_name: "derive::EmptyEnum"
+        }
+    );
+}

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -251,3 +251,9 @@ fn test_macro_newtype() {
         assert_eq!(len, newtype_len);
     }
 }
+
+#[derive(bincode::Encode, bincode::Decode)]
+pub enum EmptyEnum {}
+
+#[derive(bincode::Encode, bincode::BorrowDecode)]
+pub enum BorrowedEmptyEnum {}


### PR DESCRIPTION
bincode-derive failed on an empty enum. This PR fixes this.

Apparently if you implement a trait on an enum, an empty match statement is not sufficient. Rust seems to think the enum is populated somehow. Adding a `unreachable!()` fixed this

```rs
impl bincode::enc::Encode for BorrowedEmptyEnum {
    fn encode<E: bincode::enc::Encoder>(
        &self,
        mut encoder: E,
    ) -> core::result::Result<(), bincode::error::EncodeError> {
        match self {
            _ => core::unreachable!(), // new
        }
    }
}
```

Update: Made the `Decode` not read the byte and return a specific error for this situation

```rs
impl bincode::Decode for EmptyEnum {
    fn decode<D: bincode::de::Decoder>(
        mut decoder: D,
    ) -> core::result::Result<Self, bincode::error::DecodeError> {
        core::result::Result::Err(bincode::error::DecodeError::EmptyEnum {
            type_name: core::any::type_name::<Self>(),
        })
    }
}
```

<details>

<summary>old</summary>

Additionally the `self.variants.len() - 1` would underflow if there are no variants. `saturating_sub(1)` sets it correctly to 0

```rs
impl bincode::Decode for EmptyEnum {
    fn decode<D: bincode::de::Decoder>(
        mut decoder: D,
    ) -> core::result::Result<Self, bincode::error::DecodeError> {
        let variant_index = <u32 as bincode::Decode>::decode(&mut decoder)?;
        match variant_index {
            variant => Err(bincode::error::DecodeError::UnexpectedVariant {
                found: variant,
                type_name: "EmptyEnum",
                allowed: bincode::error::AllowedEnumVariants::Range { min: 0, max: 0 },
            }),
        }
    }
}
```

</details>