### PR TITLE
Bump virtue 0.0.4

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -16,4 +16,4 @@ description = "Implementation of #[derive(Encode, Decode)] for bincode"
 proc-macro = true
 
 [dependencies]
-virtue = "0.0.3" 
+virtue = "0.0.4" 

--- a/derive/src/derive_enum.rs
+++ b/derive/src/derive_enum.rs
@@ -88,7 +88,7 @@ impl DeriveEnum {
                             body.punct(';');
                             // If we have any fields, encode them all one by one
                             for field_name in variant.fields.names() {
-                                if field_name.has_attribute(FieldAttribute::WithSerde)? {
+                                if field_name.attributes().has_attribute(FieldAttribute::WithSerde)? {
                                     body.push_parsed(format!(
                                         "bincode::enc::Encode::encode(&bincode::serde::Compat({}), &mut encoder)?;",
                                         field_name.to_string_with_prefix(TUPLE_FIELD_PREFIX),
@@ -228,7 +228,7 @@ impl DeriveEnum {
                                         variant_body.ident(field.unwrap_ident().clone());
                                     }
                                     variant_body.punct(':');
-                                    if field.has_attribute(FieldAttribute::WithSerde)? {
+                                    if field.attributes().has_attribute(FieldAttribute::WithSerde)? {
                                         variant_body
                                             .push_parsed("<bincode::serde::Compat<_> as bincode::Decode>::decode(&mut decoder)?.0,")?;
                                     } else {
@@ -298,7 +298,7 @@ impl DeriveEnum {
                                         variant_body.ident(field.unwrap_ident().clone());
                                     }
                                     variant_body.punct(':');
-                                    if field.has_attribute(FieldAttribute::WithSerde)? {
+                                    if field.attributes().has_attribute(FieldAttribute::WithSerde)? {
                                         variant_body
                                             .push_parsed("<bincode::serde::BorrowCompat<_> as bincode::BorrowDecode>::borrow_decode(&mut decoder)?.0,")?;
                                     } else {

--- a/derive/src/derive_struct.rs
+++ b/derive/src/derive_struct.rs
@@ -25,7 +25,7 @@ impl DeriveStruct {
             .with_return_type("core::result::Result<(), bincode::error::EncodeError>")
             .body(|fn_body| {
                 for field in fields.names() {
-                    if field.has_attribute(FieldAttribute::WithSerde)? {
+                    if field.attributes().has_attribute(FieldAttribute::WithSerde)? {
                         fn_body
                             .push_parsed(format!(
                                 "bincode::Encode::encode(&bincode::serde::Compat(&self.{}), &mut encoder)?;",
@@ -73,7 +73,7 @@ impl DeriveStruct {
                         //      ...
                         // }
                         for field in fields.names() {
-                            if field.has_attribute(FieldAttribute::WithSerde)? {
+                            if field.attributes().has_attribute(FieldAttribute::WithSerde)? {
                                 struct_body
                                     .push_parsed(format!(
                                         "{}: (<bincode::serde::Compat<_> as bincode::Decode>::decode(&mut decoder)?).0,",
@@ -118,7 +118,7 @@ impl DeriveStruct {
                     ok_group.ident_str("Self");
                     ok_group.group(Delimiter::Brace, |struct_body| {
                         for field in fields.names() {
-                            if field.has_attribute(FieldAttribute::WithSerde)? {
+                            if field.attributes().has_attribute(FieldAttribute::WithSerde)? {
                                 struct_body
                                     .push_parsed(format!(
                                         "{}: (<bincode::serde::BorrowCompat<_> as bincode::de::BorrowDecode>::borrow_decode(&mut decoder)?).0,",

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "derive")]
 
 use bincode::config::Configuration;
+
 #[derive(bincode::Encode, PartialEq, Debug)]
 pub(crate) struct Test<T> {
     a: T,
@@ -217,14 +218,36 @@ fn test_c_style_enum() {
 
 macro_rules! macro_newtype {
     ($name:ident) => {
-        #[derive(bincode::Encode, bincode::Decode)]
-        #[derive(PartialEq, Eq)]
+        #[derive(bincode::Encode, bincode::Decode, PartialEq, Eq, Debug)]
         pub struct $name(pub usize);
-    }
+    };
 }
-macro_newtype!(MacroNewtype);
+macro_newtype!(MacroNewType);
 
 #[test]
 fn test_macro_newtype() {
+    for val in [0, 100, usize::MAX] {
+        let mut usize_slice = [0u8; 10];
+        let usize_len =
+            bincode::encode_into_slice(val, &mut usize_slice, Configuration::standard()).unwrap();
 
+        let mut newtype_slice = [0u8; 10];
+        let newtype_len = bincode::encode_into_slice(
+            MacroNewType(val),
+            &mut newtype_slice,
+            Configuration::standard(),
+        )
+        .unwrap();
+
+        assert_eq!(usize_len, newtype_len);
+        assert_eq!(usize_slice, newtype_slice);
+
+        let (newtype, len) = bincode::decode_from_slice::<MacroNewType, _>(
+            &newtype_slice,
+            Configuration::standard(),
+        )
+        .unwrap();
+        assert_eq!(newtype, MacroNewType(val));
+        assert_eq!(len, newtype_len);
+    }
 }

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -214,3 +214,17 @@ fn test_c_style_enum() {
     assert_eq!(de(6).unwrap(), CStyleEnum::E);
     assert_eq!(de(7), expected_err(7));
 }
+
+macro_rules! macro_newtype {
+    ($name:ident) => {
+        #[derive(bincode::Encode, bincode::Decode)]
+        #[derive(PartialEq, Eq)]
+        pub struct $name(pub usize);
+    }
+}
+macro_newtype!(MacroNewtype);
+
+#[test]
+fn test_macro_newtype() {
+
+}


### PR DESCRIPTION
Virtue changes:
- Fixes an issue when implementing derive on a `macro_rules!` target: https://github.com/bincode-org/virtue/pull/4
- AttributeAccess extension methods: https://github.com/bincode-org/virtue/pull/2

Also adds a test for said `macro_rules!` change. This test fails on virtue 0.0.3