### PR TITLE
Implemented the newly stabilized CString::from_vec_with_nul method

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -139,11 +139,18 @@ pub enum DecodeError {
         duration: core::time::Duration,
     },
 
-    /// The decoder tried to decode a `CStr` or `CString`, but the incoming data contained a 0 byte
+    /// The decoder tried to decode a `CStr`, but the incoming data contained a 0 byte
     #[cfg(feature = "std")]
     CStrNulError {
         /// The inner exception
         inner: std::ffi::FromBytesWithNulError,
+    },
+
+    /// The decoder tried to decode a `CString`, but the incoming data contained a 0 byte
+    #[cfg(feature = "std")]
+    CStringNulError {
+        /// The inner exception
+        inner: std::ffi::FromVecWithNulError,
     },
 
     /// An uncommon error occured, see the inner text for more information

--- a/src/features/impl_std.rs
+++ b/src/features/impl_std.rs
@@ -128,15 +128,8 @@ impl Encode for CString {
 
 impl Decode for CString {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
-        // BlockedTODO: https://github.com/rust-lang/rust/issues/73179
-        // use `from_vec_with_nul` instead, combined with:
-        // let bytes = std::vec::Vec::<u8>::decode(decoder)?;
-
-        // now we have to allocate twice unfortunately
-        let vec: std::vec::Vec<u8> = std::vec::Vec::decode(decoder)?;
-        let cstr =
-            CStr::from_bytes_with_nul(&vec).map_err(|e| DecodeError::CStrNulError { inner: e })?;
-        Ok(cstr.into())
+        let vec = std::vec::Vec::decode(decoder)?;
+        CString::from_vec_with_nul(vec).map_err(|inner| DecodeError::CStringNulError { inner })
     }
 }
 


### PR DESCRIPTION
Closes #416 

May not compile yet if github actions isn't on 1.58 yet