### PR TITLE
Support slice lengths to be encoded as an u32

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,15 @@ pub enum EncodeError {
         type_name: &'static str,
     },
 
+    /// The slice length doesn't fit into the encoded slice length type.
+    ///
+    /// This error can happen if an u32 is used to encode slice lengths on a 64
+    /// bit architecture. This is only enabled if the [with_u32_slice_length_encoding]
+    /// config option is used.
+    ///
+    /// [with_u32_slice_length_encoding]: crate::config::Configuration::with_u32_slice_length_encoding
+    SliceLength(usize),
+
     /// An uncommon error occurred, see the inner text for more information
     Other(&'static str),
 

--- a/tests/basic_types.rs
+++ b/tests/basic_types.rs
@@ -142,6 +142,31 @@ fn test_slice() {
 }
 
 #[test]
+fn test_slice_u32_len() {
+    let mut buffer = [0u8; 32];
+    let input: &[u8] = &[1, 2, 3, 4, 5, 6, 7, 8];
+    bincode::encode_into_slice(
+        input,
+        &mut buffer,
+        bincode::config::standard()
+            .with_fixed_int_encoding()
+            .with_u32_slice_length_encoding(),
+    )
+    .unwrap();
+    assert_eq!(&buffer[..12], &[8, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8]);
+
+    let (output, len): (&[u8], usize) = bincode::decode_from_slice(
+        &buffer,
+        bincode::config::standard()
+            .with_u32_slice_length_encoding()
+            .with_fixed_int_encoding(),
+    )
+    .unwrap();
+    assert_eq!(input, output);
+    assert_eq!(len, 12);
+}
+
+#[test]
 fn test_option_slice() {
     let mut buffer = [0u8; 32];
     let input: Option<&[u8]> = Some(&[1, 2, 3, 4, 5, 6, 7]);


### PR DESCRIPTION
Slice lengths (an usize) are encoded in bincode as a u64 value. Given that the width of usize is platform-specific, an usize value encoded on a platform with a wider usize has the potential for decoding to fail on a platform with a narrower usize. If we know the usize width of the target decoding platform at encoding time, it could be preferable to fail at encoding time instead, giving us the possibility to detect this error.

This commit introduces the ability to choose, at encoding time, between slices being 32 or 64 bits wide. These widths are chosen for being the two most common slice length type widths on common architectures. If a slice length value is given that is out of range for the chosen slice length type, an error will happen at encoding time.