### PR TITLE
Made the compatibility check also include bincode 2 serde, and added comments

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -158,6 +158,33 @@ fi",
         }
       ]
     },
+    "compatibility": {
+      "name": "Compatibility",
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v2",
+          "name": "Checkout"
+        },
+        {
+          "uses": "actions-rs/toolchain@v1",
+          "with": {
+            "profile": "minimal",
+            "toolchain": "stable",
+            "override": true,
+          },
+          "name": "Install Rust stable"
+        },
+        {
+          "uses": "actions-rs/cargo@v1",
+          "with": {
+            "command": "test",
+            "args": "--manifest-path compatibility/Cargo.toml"
+          },
+          "name": "Run compatibility tests"
+        }
+      ]
+    },
     "coverage": {
       "name": "Code Coverage",
       "runs-on": "ubuntu-latest",

--- a/compatibility/Cargo.toml
+++ b/compatibility/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bincode_2 = { path = "..", package = "bincode" }
+bincode_2 = { path = "..", package = "bincode", features = ["serde"] }
 bincode_1 = { version = "1", package = "bincode" }
 serde = { version = "1", features = ["derive"] }
 rand = "0.8"

--- a/compatibility/src/lib.rs
+++ b/compatibility/src/lib.rs
@@ -17,25 +17,33 @@ where
     C: bincode_2::config::Config,
     O: bincode_1::Options + Copy,
 {
-    let bincode_1_output = bincode_1_options.serialize(t).unwrap();
-    let bincode_2_output = bincode_2::encode_to_vec(t, bincode_2_config).unwrap();
+    // This is what bincode 1 serializes to. This will be our comparison value.
+    let encoded = bincode_1_options.serialize(t).unwrap();
 
+    // Test bincode 2 encode
+    let bincode_2_output = bincode_2::encode_to_vec(t, bincode_2_config).unwrap();
+    assert_eq!(encoded, bincode_2_output, "{:?} serializes differently", t);
+
+    // Test bincode 2 serde serialize
+    let bincode_2_serde_output = bincode_2::serde::encode_to_vec(t, bincode_2_config).unwrap();
     assert_eq!(
-        bincode_1_output, bincode_2_output,
+        encoded, bincode_2_serde_output,
         "{:?} serializes differently",
         t
     );
 
-    let decoded: T = bincode_1_options.deserialize(&bincode_1_output).unwrap();
-    assert_eq!(&decoded, t);
-    let decoded: T = bincode_1_options.deserialize(&bincode_2_output).unwrap();
+    // Test bincode 1 deserialize
+    let decoded: T = bincode_1_options.deserialize(&encoded).unwrap();
     assert_eq!(&decoded, t);
 
-    let decoded: T = bincode_2::decode_from_slice(&bincode_1_output, bincode_2_config)
+    // Test bincode 2 decode
+    let decoded: T = bincode_2::decode_from_slice(&encoded, bincode_2_config)
         .unwrap()
         .0;
     assert_eq!(&decoded, t);
-    let decoded: T = bincode_2::decode_from_slice(&bincode_2_output, bincode_2_config)
+
+    // Test bincode 2 serde deserialize
+    let decoded: T = bincode_2::serde::decode_from_slice(&encoded, bincode_2_config)
         .unwrap()
         .0;
     assert_eq!(&decoded, t);


### PR DESCRIPTION
Some of the code was redundant because we confirmed that the `bincode_1_output` was identical to the `bincode_2_output`. Therefor deserializing the same slice twice won't give different results.

Added a validation that `bincode_2::serde` also (de)serializes the same.