### PR TITLE
Fix/issue 500

### DIFF
--- a/compatibility/src/lib.rs
+++ b/compatibility/src/lib.rs
@@ -3,6 +3,7 @@
 use ::rand::Rng;
 use bincode_1::Options;
 
+mod misc;
 mod rand;
 mod sway;
 
@@ -19,6 +20,8 @@ where
 {
     // This is what bincode 1 serializes to. This will be our comparison value.
     let encoded = bincode_1_options.serialize(t).unwrap();
+
+    println!("Encoded {:?} as {:?}", t, encoded);
 
     // Test bincode 2 encode
     let bincode_2_output = bincode_2::encode_to_vec(t, bincode_2_config).unwrap();

--- a/compatibility/src/misc.rs
+++ b/compatibility/src/misc.rs
@@ -1,0 +1,10 @@
+#[test]
+fn test() {
+    super::test_same((1,));
+    super::test_same(Option::<u32>::Some(5));
+    super::test_same(Option::<u32>::None);
+    super::test_same(Result::<u32, u8>::Ok(5));
+    super::test_same(Result::<u32, u8>::Err(5));
+    super::test_same(std::net::Ipv4Addr::LOCALHOST);
+    super::test_same(std::net::Ipv6Addr::LOCALHOST);
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -162,6 +162,8 @@ impl<E, I, A, L> Configuration<E, I, A, L> {
     }
 
     /// Skip writing the length of fixed size arrays (`[u8; N]`) before writing the array
+    ///
+    /// **NOTE:** This is not supported if you're using the `bincode::serde::*` functions, the `#[bincode(with_serde)]` attribute, or the `Compat` struct.
     pub const fn skip_fixed_array_length(self) -> Configuration<E, I, SkipFixedArrayLength, L> {
         generate()
     }

--- a/src/de/impls.rs
+++ b/src/de/impls.rs
@@ -512,7 +512,7 @@ where
     U: Decode,
 {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
-        let is_ok = u8::decode(decoder)?;
+        let is_ok = u32::decode(decoder)?;
         match is_ok {
             0 => {
                 let t = T::decode(decoder)?;

--- a/src/enc/impls.rs
+++ b/src/enc/impls.rs
@@ -387,11 +387,11 @@ where
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
         match self {
             Ok(val) => {
-                0u8.encode(encoder)?;
+                0u32.encode(encoder)?;
                 val.encode(encoder)
             }
             Err(err) => {
-                1u8.encode(encoder)?;
+                1u32.encode(encoder)?;
                 err.encode(encoder)
             }
         }

--- a/src/features/impl_std.rs
+++ b/src/features/impl_std.rs
@@ -268,25 +268,29 @@ impl Decode for IpAddr {
 
 impl Encode for Ipv4Addr {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
-        self.octets().encode(encoder)
+        encoder.writer().write(&self.octets())
     }
 }
 
 impl Decode for Ipv4Addr {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
-        Ok(Self::from(<[u8; 4]>::decode(decoder)?))
+        let mut buff = [0u8; 4];
+        decoder.reader().read(&mut buff)?;
+        Ok(Self::from(buff))
     }
 }
 
 impl Encode for Ipv6Addr {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
-        self.octets().encode(encoder)
+        encoder.writer().write(&self.octets())
     }
 }
 
 impl Decode for Ipv6Addr {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
-        Ok(Self::from(<[u8; 16]>::decode(decoder)?))
+        let mut buff = [0u8; 16];
+        decoder.reader().read(&mut buff)?;
+        Ok(Self::from(buff))
     }
 }
 

--- a/src/features/serde/de_borrowed.rs
+++ b/src/features/serde/de_borrowed.rs
@@ -235,8 +235,8 @@ impl<'a, 'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'a, 'de
     where
         V: serde_incl::de::Visitor<'de>,
     {
-        let len = u32::decode(&mut self.de)?;
-        self.deserialize_tuple(len as usize, visitor)
+        let len = usize::decode(&mut self.de)?;
+        self.deserialize_tuple(len, visitor)
     }
 
     fn deserialize_tuple<V>(mut self, len: usize, visitor: V) -> Result<V::Value, Self::Error>

--- a/src/features/serde/de_borrowed.rs
+++ b/src/features/serde/de_borrowed.rs
@@ -13,6 +13,9 @@ where
     T: Deserialize<'de>,
     C: Config,
 {
+    if C::SKIP_FIXED_ARRAY_LENGTH {
+        return Err(SerdeDecodeError::SkipFixedArrayLengthNotSupported.into());
+    }
     let reader = crate::de::read::SliceReader::new(slice);
     let mut decoder = crate::de::DecoderImpl::new(reader, config);
     let serde_decoder = SerdeDecoder {
@@ -72,6 +75,15 @@ impl<'a, 'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'a, 'de
         visitor.visit_i64(Decode::decode(&mut self.de)?)
     }
 
+    serde_incl::serde_if_integer128! {
+        fn deserialize_i128<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: serde_incl::de::Visitor<'de>,
+        {
+            visitor.visit_i128(Decode::decode(&mut self.de)?)
+        }
+    }
+
     fn deserialize_u8<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: serde_incl::de::Visitor<'de>,
@@ -98,6 +110,15 @@ impl<'a, 'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'a, 'de
         V: serde_incl::de::Visitor<'de>,
     {
         visitor.visit_u64(Decode::decode(&mut self.de)?)
+    }
+
+    serde_incl::serde_if_integer128! {
+        fn deserialize_u128<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: serde_incl::de::Visitor<'de>,
+        {
+            visitor.visit_u128(Decode::decode(&mut self.de)?)
+        }
     }
 
     fn deserialize_f32<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
@@ -366,6 +387,10 @@ impl<'a, 'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'a, 'de
         V: serde_incl::de::Visitor<'de>,
     {
         Err(SerdeDecodeError::IgnoredAnyNotSupported.into())
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
     }
 }
 

--- a/src/features/serde/de_owned.rs
+++ b/src/features/serde/de_owned.rs
@@ -285,7 +285,7 @@ impl<'a, 'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'a, DE> {
         V: serde_incl::de::Visitor<'de>,
     {
         let len = usize::decode(&mut self.de)?;
-        self.deserialize_tuple(len as usize, visitor)
+        self.deserialize_tuple(len, visitor)
     }
 
     fn deserialize_tuple<V>(mut self, len: usize, visitor: V) -> Result<V::Value, Self::Error>

--- a/src/features/serde/de_owned.rs
+++ b/src/features/serde/de_owned.rs
@@ -16,6 +16,9 @@ where
     T: DeserializeOwned,
     C: Config,
 {
+    if C::SKIP_FIXED_ARRAY_LENGTH {
+        return Err(SerdeDecodeError::SkipFixedArrayLengthNotSupported.into());
+    }
     let reader = crate::de::read::SliceReader::new(slice);
     let mut decoder = crate::de::DecoderImpl::new(reader, config);
     let serde_decoder = SerdeDecoder { de: &mut decoder };
@@ -31,6 +34,9 @@ pub fn decode_from_std_read<D: DeserializeOwned, C: Config, R: std::io::Read>(
     src: &mut R,
     config: C,
 ) -> Result<D, DecodeError> {
+    if C::SKIP_FIXED_ARRAY_LENGTH {
+        return Err(SerdeDecodeError::SkipFixedArrayLengthNotSupported.into());
+    }
     let reader = crate::IoReader::new(src);
     let mut decoder = crate::de::DecoderImpl::new(reader, config);
     let serde_decoder = SerdeDecoder { de: &mut decoder };
@@ -46,6 +52,9 @@ pub fn decode_from_reader<D: DeserializeOwned, R: Reader, C: Config>(
     reader: R,
     config: C,
 ) -> Result<D, DecodeError> {
+    if C::SKIP_FIXED_ARRAY_LENGTH {
+        return Err(SerdeDecodeError::SkipFixedArrayLengthNotSupported.into());
+    }
     let mut decoder = crate::de::DecoderImpl::<_, C>::new(reader, config);
     let serde_decoder = SerdeDecoder { de: &mut decoder };
     D::deserialize(serde_decoder)
@@ -100,6 +109,15 @@ impl<'a, 'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'a, DE> {
         visitor.visit_i64(Decode::decode(&mut self.de)?)
     }
 
+    serde_incl::serde_if_integer128! {
+        fn deserialize_i128<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: serde_incl::de::Visitor<'de>,
+        {
+            visitor.visit_i128(Decode::decode(&mut self.de)?)
+        }
+    }
+
     fn deserialize_u8<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: serde_incl::de::Visitor<'de>,
@@ -126,6 +144,15 @@ impl<'a, 'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'a, DE> {
         V: serde_incl::de::Visitor<'de>,
     {
         visitor.visit_u64(Decode::decode(&mut self.de)?)
+    }
+
+    serde_incl::serde_if_integer128! {
+        fn deserialize_u128<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: serde_incl::de::Visitor<'de>,
+        {
+            visitor.visit_u128(Decode::decode(&mut self.de)?)
+        }
     }
 
     fn deserialize_f32<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
@@ -406,6 +433,10 @@ impl<'a, 'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'a, DE> {
         V: serde_incl::de::Visitor<'de>,
     {
         Err(SerdeDecodeError::IgnoredAnyNotSupported.into())
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
     }
 }
 

--- a/src/features/serde/de_owned.rs
+++ b/src/features/serde/de_owned.rs
@@ -257,7 +257,7 @@ impl<'a, 'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'a, DE> {
     where
         V: serde_incl::de::Visitor<'de>,
     {
-        let len = u32::decode(&mut self.de)?;
+        let len = usize::decode(&mut self.de)?;
         self.deserialize_tuple(len as usize, visitor)
     }
 

--- a/src/features/serde/mod.rs
+++ b/src/features/serde/mod.rs
@@ -89,6 +89,9 @@ pub enum DecodeError {
     /// Serde tried decoding a borrowed value from an owned reader. Use `serde_decode_borrowed_from_*` instead
     CannotBorrowOwnedData,
 
+    /// Serde does not support skipping fixed array lengths
+    SkipFixedArrayLengthNotSupported,
+
     /// Could not allocate data like `String` and `Vec<u8>`
     #[cfg(not(feature = "alloc"))]
     CannotAllocate,
@@ -135,6 +138,9 @@ impl Into<crate::error::DecodeError> for DecodeError {
 pub enum EncodeError {
     /// Serde provided bincode with a sequence without a length, which is not supported in bincode
     SequenceMustHaveLength,
+
+    /// Serde does not support skipping fixed array lengths
+    SkipFixedArrayLengthNotSupported,
 
     /// [Serializer::collect_str] got called but bincode was unable to allocate memory.
     #[cfg(not(feature = "alloc"))]

--- a/src/features/serde/ser.rs
+++ b/src/features/serde/ser.rs
@@ -230,7 +230,6 @@ where
     }
 
     fn serialize_tuple(self, _: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        // len.encode(&mut self.enc)?;
         Ok(self)
     }
 

--- a/src/features/serde/ser.rs
+++ b/src/features/serde/ser.rs
@@ -16,6 +16,9 @@ where
     T: Serialize,
     C: Config,
 {
+    if C::SKIP_FIXED_ARRAY_LENGTH {
+        return Err(SerdeEncodeError::SkipFixedArrayLengthNotSupported.into());
+    }
     let mut encoder = crate::enc::EncoderImpl::new(crate::VecWriter::default(), config);
     let serializer = SerdeEncoder { enc: &mut encoder };
     t.serialize(serializer)?;
@@ -28,6 +31,9 @@ where
     T: Serialize,
     C: Config,
 {
+    if C::SKIP_FIXED_ARRAY_LENGTH {
+        return Err(SerdeEncodeError::SkipFixedArrayLengthNotSupported.into());
+    }
     let mut encoder =
         crate::enc::EncoderImpl::new(crate::enc::write::SliceWriter::new(slice), config);
     let serializer = SerdeEncoder { enc: &mut encoder };
@@ -45,6 +51,9 @@ pub fn encode_into_writer<E: Serialize, W: Writer, C: Config>(
     writer: W,
     config: C,
 ) -> Result<(), EncodeError> {
+    if C::SKIP_FIXED_ARRAY_LENGTH {
+        return Err(SerdeEncodeError::SkipFixedArrayLengthNotSupported.into());
+    }
     let mut encoder = crate::enc::EncoderImpl::<_, C>::new(writer, config);
     let serializer = SerdeEncoder { enc: &mut encoder };
     val.serialize(serializer)?;
@@ -62,6 +71,9 @@ pub fn encode_into_std_write<E: Serialize, C: Config, W: std::io::Write>(
     dst: &mut W,
     config: C,
 ) -> Result<usize, EncodeError> {
+    if C::SKIP_FIXED_ARRAY_LENGTH {
+        return Err(SerdeEncodeError::SkipFixedArrayLengthNotSupported.into());
+    }
     let writer = crate::IoWriter::new(dst);
     let mut encoder = crate::enc::EncoderImpl::<_, C>::new(writer, config);
     let serializer = SerdeEncoder { enc: &mut encoder };
@@ -109,6 +121,12 @@ where
         v.encode(self.enc)
     }
 
+    serde_incl::serde_if_integer128! {
+        fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
+            v.encode(self.enc)
+        }
+    }
+
     fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
         v.encode(self.enc)
     }
@@ -123,6 +141,12 @@ where
 
     fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
         v.encode(self.enc)
+    }
+
+    serde_incl::serde_if_integer128! {
+        fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
+            v.encode(self.enc)
+        }
     }
 
     fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
@@ -205,8 +229,8 @@ where
         Ok(Compound { enc: self.enc })
     }
 
-    fn serialize_tuple(mut self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        len.encode(&mut self.enc)?;
+    fn serialize_tuple(self, _: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        // len.encode(&mut self.enc)?;
         Ok(self)
     }
 
@@ -261,6 +285,10 @@ where
         T: core::fmt::Display,
     {
         Err(SerdeEncodeError::CannotCollectStr.into())
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
     }
 }
 

--- a/tests/alloc.rs
+++ b/tests/alloc.rs
@@ -6,8 +6,9 @@ mod utils;
 
 use alloc::borrow::Cow;
 use alloc::collections::*;
+#[cfg(not(feature = "serde"))]
 use alloc::rc::Rc;
-#[cfg(feature = "atomic")]
+#[cfg(all(feature = "atomic", not(feature = "serde")))]
 use alloc::sync::Arc;
 use utils::{the_same, the_same_with_comparer};
 
@@ -58,8 +59,11 @@ fn test_alloc_commons() {
     the_same(Box::<[u32]>::from(vec![1, 2, 3, 4, 5]));
     the_same(Cow::<u32>::Owned(5));
     the_same(Cow::<u32>::Borrowed(&5));
+    // Serde doesn't support Rc<u32>
+    #[cfg(not(feature = "serde"))]
     the_same(Rc::<u32>::new(5));
-    #[cfg(feature = "atomic")]
+    // serde doesn't support Arc<u32>
+    #[cfg(all(feature = "atomic", not(feature = "serde")))]
     the_same(Arc::<u32>::new(5));
     the_same_with_comparer(
         {

--- a/tests/basic_types.rs
+++ b/tests/basic_types.rs
@@ -48,6 +48,7 @@ fn test_numbers() {
 
     // arrays
     #[rustfmt::skip]
+    #[cfg(not(feature = "serde"))] // serde doesn't support arrays this big
     the_same([
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
         17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
@@ -217,6 +218,21 @@ fn test_array() {
         bincode::decode_from_slice(&mut buffer[..10], bincode::config::standard()).unwrap();
     assert_eq!(input, output);
     assert_eq!(len, 10);
+
+    let mut buffer = [0u8; 32];
+    let input: [u8; 1] = [1];
+    let config = bincode::config::standard()
+        .write_fixed_array_length()
+        .with_fixed_int_encoding()
+        .with_little_endian();
+    let len = bincode::encode_into_slice(input, &mut buffer, config).unwrap();
+    assert_eq!(len, 9);
+    assert_eq!(&buffer[..9], &[1, 0, 0, 0, 0, 0, 0, 0, 1]);
+
+    let (output, len): (&[u8], usize) =
+        bincode::decode_from_slice(&mut buffer[..9], config).unwrap();
+    assert_eq!(input, output);
+    assert_eq!(len, 9);
 }
 
 #[test]

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -17,3 +17,6 @@ mod issue_474;
 
 #[path = "issues/issue_498.rs"]
 mod issue_498;
+
+#[path = "issues/issue_500.rs"]
+mod issue_500;

--- a/tests/issues/issue_474.rs
+++ b/tests/issues/issue_474.rs
@@ -62,7 +62,7 @@ impl MemCache {
     where
         T: Send + Sync + serde_incl::Serialize,
     {
-        let config = bincode::config::standard();
+        let config = bincode::config::standard().write_fixed_array_length();
         let mut guard = self.cache.write().unwrap();
 
         let encoded = bincode::serde::encode_to_vec(&cache_data, config)?;
@@ -76,7 +76,7 @@ impl MemCache {
     where
         T: Send + Sync + DeserializeOwned,
     {
-        let config = bincode::config::standard();
+        let config = bincode::config::standard().write_fixed_array_length();
         let guard = self.cache.read().unwrap();
         let cache_item = guard.get(key).unwrap();
         let (decoded, _len): (T, usize) =

--- a/tests/issues/issue_500.rs
+++ b/tests/issues/issue_500.rs
@@ -1,0 +1,37 @@
+#![cfg(all(feature = "serde", feature = "derive", feature = "std"))]
+
+extern crate std;
+
+type NodeId = u64;
+
+use std::collections::BTreeSet;
+
+#[derive(
+    bincode::Encode,
+    bincode::Decode,
+    serde_derive::Serialize,
+    serde_derive::Deserialize,
+    Debug,
+    PartialEq,
+)]
+#[serde(crate = "serde_incl")]
+pub struct Membership {
+    /// learners set
+    learners: BTreeSet<NodeId>,
+}
+
+#[test]
+fn test() {
+    let mut start = Membership {
+        learners: BTreeSet::new(),
+    };
+    start.learners.insert(1);
+
+    let config = bincode::config::legacy();
+    let encoded = bincode::encode_to_vec(&start, config).unwrap();
+    std::dbg!(&encoded);
+    let decoded: Membership = bincode::serde::decode_from_slice(&encoded, config)
+        .unwrap()
+        .0;
+    assert_eq!(start, decoded);
+}

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -24,12 +24,17 @@ fn test_serde_round_trip() {
     assert_eq!(result.b, 0);
 
     // validate bincode working
-    let bytes =
-        bincode::encode_to_vec(SerdeRoundtrip { a: 15, b: 15 }, bincode::config::standard())
-            .unwrap();
+    let bytes = bincode::encode_to_vec(
+        SerdeRoundtrip { a: 15, b: 15 },
+        bincode::config::standard().write_fixed_array_length(),
+    )
+    .unwrap();
     assert_eq!(bytes, &[15, 15]);
-    let (result, len): (SerdeRoundtrip, usize) =
-        bincode::decode_from_slice(&bytes, bincode::config::standard()).unwrap();
+    let (result, len): (SerdeRoundtrip, usize) = bincode::decode_from_slice(
+        &bytes,
+        bincode::config::standard().write_fixed_array_length(),
+    )
+    .unwrap();
     assert_eq!(result.a, 15);
     assert_eq!(result.b, 15);
     assert_eq!(len, 2);
@@ -61,17 +66,28 @@ fn test_serialize_deserialize_borrowed_data() {
     ];
 
     let mut result = [0u8; 20];
-    let len = bincode::serde::encode_into_slice(&input, &mut result, bincode::config::standard())
-        .unwrap();
+    let len = bincode::serde::encode_into_slice(
+        &input,
+        &mut result,
+        bincode::config::standard().write_fixed_array_length(),
+    )
+    .unwrap();
     let result = &result[..len];
     assert_eq!(result, expected);
 
-    let result = bincode::serde::encode_to_vec(&input, bincode::config::standard()).unwrap();
+    let result = bincode::serde::encode_to_vec(
+        &input,
+        bincode::config::standard().write_fixed_array_length(),
+    )
+    .unwrap();
 
     assert_eq!(result, expected);
 
-    let output: SerdeWithBorrowedData =
-        bincode::serde::decode_borrowed_from_slice(&result, bincode::config::standard()).unwrap();
+    let output: SerdeWithBorrowedData = bincode::serde::decode_borrowed_from_slice(
+        &result,
+        bincode::config::standard().write_fixed_array_length(),
+    )
+    .unwrap();
     assert_eq!(
         SerdeWithBorrowedData {
             b: 0, // remember: b is skipped
@@ -107,17 +123,28 @@ fn test_serialize_deserialize_owned_data() {
     ];
 
     let mut result = [0u8; 20];
-    let len = bincode::serde::encode_into_slice(&input, &mut result, bincode::config::standard())
-        .unwrap();
+    let len = bincode::serde::encode_into_slice(
+        &input,
+        &mut result,
+        bincode::config::standard().write_fixed_array_length(),
+    )
+    .unwrap();
     let result = &result[..len];
     assert_eq!(result, expected);
 
-    let result = bincode::serde::encode_to_vec(&input, bincode::config::standard()).unwrap();
+    let result = bincode::serde::encode_to_vec(
+        &input,
+        bincode::config::standard().write_fixed_array_length(),
+    )
+    .unwrap();
 
     assert_eq!(result, expected);
 
-    let (output, len): (SerdeWithOwnedData, usize) =
-        bincode::serde::decode_from_slice(&result, bincode::config::standard()).unwrap();
+    let (output, len): (SerdeWithOwnedData, usize) = bincode::serde::decode_from_slice(
+        &result,
+        bincode::config::standard().write_fixed_array_length(),
+    )
+    .unwrap();
     assert_eq!(
         SerdeWithOwnedData {
             b: 0, // remember: b is skipped
@@ -161,12 +188,19 @@ mod derive {
             T: bincode::Encode + bincode::Decode + PartialEq + core::fmt::Debug,
         {
             let mut slice = [0u8; 100];
-            let len = bincode::encode_into_slice(&start, &mut slice, bincode::config::standard())
-                .unwrap();
+            let len = bincode::encode_into_slice(
+                &start,
+                &mut slice,
+                bincode::config::standard().write_fixed_array_length(),
+            )
+            .unwrap();
             assert_eq!(len, expected_len);
             let slice = &slice[..len];
-            let (result, len): (T, usize) =
-                bincode::decode_from_slice(&slice, bincode::config::standard()).unwrap();
+            let (result, len): (T, usize) = bincode::decode_from_slice(
+                &slice,
+                bincode::config::standard().write_fixed_array_length(),
+            )
+            .unwrap();
 
             assert_eq!(start, result);
             assert_eq!(len, expected_len);

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -2,15 +2,16 @@ use core::fmt::Debug;
 
 fn the_same_with_config<V, C, CMP>(element: &V, config: C, cmp: CMP)
 where
-    V: bincode::Encode + bincode::Decode + Debug + 'static,
+    V: TheSameTrait,
     C: bincode::config::Config,
     CMP: Fn(&V, &V) -> bool,
 {
     let mut buffer = [0u8; 2048];
     let len = bincode::encode_into_slice(&element, &mut buffer, config).unwrap();
     println!(
-        "{:?}: {:?} ({:?})",
+        "{:?} ({}): {:?} ({:?})",
         element,
+        core::any::type_name::<V>(),
         &buffer[..len],
         core::any::type_name::<C>()
     );
@@ -25,11 +26,27 @@ where
         &buffer[..len],
     );
     assert_eq!(len, decoded_len);
+
+    #[cfg(feature = "serde")]
+    // skip_fixed_array_length is not supposed on serde
+    if !C::SKIP_FIXED_ARRAY_LENGTH {
+        let encoded = bincode::serde::encode_to_vec(&element, config).unwrap();
+        assert_eq!(&buffer[..len], &encoded);
+        let (decoded, decoded_len) = bincode::serde::decode_from_slice(&encoded, config).unwrap();
+        assert!(
+            cmp(&element, &decoded),
+            "Comparison failed\nDecoded:  {:?}\nExpected: {:?}\nBytes: {:?}",
+            decoded,
+            element,
+            &buffer[..len],
+        );
+        assert_eq!(decoded_len, len);
+    }
 }
 
 pub fn the_same_with_comparer<V, CMP>(element: V, cmp: CMP)
 where
-    V: bincode::Encode + bincode::Decode + Debug + 'static,
+    V: TheSameTrait,
     CMP: Fn(&V, &V) -> bool,
 {
     // A matrix of each different config option possible
@@ -99,10 +116,33 @@ where
     );
 }
 
-#[allow(dead_code)] // This is not used in every test
-pub fn the_same<V>(element: V)
-where
-    V: bincode::Encode + bincode::Decode + PartialEq + Debug + 'static,
+#[cfg(feature = "serde")]
+pub trait TheSameTrait:
+    bincode::Encode
+    + bincode::Decode
+    + serde_incl::de::DeserializeOwned
+    + serde_incl::Serialize
+    + Debug
+    + 'static
 {
+}
+#[cfg(feature = "serde")]
+impl<T> TheSameTrait for T where
+    T: bincode::Encode
+        + bincode::Decode
+        + serde_incl::de::DeserializeOwned
+        + serde_incl::Serialize
+        + Debug
+        + 'static
+{
+}
+
+#[cfg(not(feature = "serde"))]
+pub trait TheSameTrait: bincode::Encode + bincode::Decode + Debug + 'static {}
+#[cfg(not(feature = "serde"))]
+impl<T> TheSameTrait for T where T: bincode::Encode + bincode::Decode + Debug + 'static {}
+
+#[allow(dead_code)] // This is not used in every test
+pub fn the_same<V: TheSameTrait + PartialEq>(element: V) {
     the_same_with_comparer(element, |a, b| a == b);
 }


### PR DESCRIPTION
-   Fixed an issue where serde would decode a sequence with an u32 instead of a usize
-   Added serde to the `the_same` test for roundtrips, fixed several issues.
-   Fixed backwards compatibility for result, ipv4addr and ipv6addr