### PR TITLE
Reference implementations for Reader and Writer

### DIFF
--- a/src/de/read.rs
+++ b/src/de/read.rs
@@ -31,7 +31,7 @@ pub trait Reader {
     fn consume(&mut self, _: usize) {}
 }
 
-impl<'a, T> Reader for &'a mut T
+impl<T> Reader for &mut T
 where
     T: Reader,
 {

--- a/src/enc/write.rs
+++ b/src/enc/write.rs
@@ -12,6 +12,13 @@ pub trait Writer {
     fn write(&mut self, bytes: &[u8]) -> Result<(), EncodeError>;
 }
 
+impl<T: Writer> Writer for &mut T {
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) -> Result<(), EncodeError> {
+        (**self).write(bytes)
+    }
+}
+
 /// A helper struct that implements `Writer` for a `&[u8]` slice.
 ///
 /// ```


### PR DESCRIPTION
I added a `Writer` implementation for `&mut T: Writer`, as there's one for Reader already.

I also removed unnecessary lifetime generics from the reference implementation for Reader since they are not needed.