### PR TITLE
Made config::standard() implement .write_fixed_array_header() by default

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -39,7 +39,7 @@ use core::marker::PhantomData;
 /// [skip_fixed_array_length]: #method.skip_fixed_array_length
 /// [write_fixed_array_length]: #method.write_fixed_array_length
 #[derive(Copy, Clone)]
-pub struct Configuration<E = LittleEndian, I = Varint, A = SkipFixedArrayLength, L = NoLimit> {
+pub struct Configuration<E = LittleEndian, I = Varint, A = WriteFixedArrayLength, L = NoLimit> {
     _e: PhantomData<E>,
     _i: PhantomData<I>,
     _a: PhantomData<A>,
@@ -49,7 +49,7 @@ pub struct Configuration<E = LittleEndian, I = Varint, A = SkipFixedArrayLength,
 /// The default config for bincode 2.0. By default this will be:
 /// - Little endian
 /// - Variable int encoding
-/// - Skip fixed array length
+/// - Write fixed array length
 pub const fn standard() -> Configuration {
     generate()
 }

--- a/tests/basic_types.rs
+++ b/tests/basic_types.rs
@@ -212,7 +212,10 @@ fn test_array() {
     let mut buffer = [0u8; 32];
     let input: [u8; 10] = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
     bincode::encode_into_slice(input, &mut buffer, bincode::config::standard()).unwrap();
-    assert_eq!(&buffer[..11], &[10, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]);
+    assert_eq!(
+        &buffer[..11],
+        &[10, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+    );
 
     let (output, len): ([u8; 10], usize) =
         bincode::decode_from_slice(&mut buffer[..11], bincode::config::standard()).unwrap();

--- a/tests/basic_types.rs
+++ b/tests/basic_types.rs
@@ -212,12 +212,12 @@ fn test_array() {
     let mut buffer = [0u8; 32];
     let input: [u8; 10] = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
     bincode::encode_into_slice(input, &mut buffer, bincode::config::standard()).unwrap();
-    assert_eq!(&buffer[..10], &[10, 20, 30, 40, 50, 60, 70, 80, 90, 100]);
+    assert_eq!(&buffer[..11], &[10, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]);
 
     let (output, len): ([u8; 10], usize) =
-        bincode::decode_from_slice(&mut buffer[..10], bincode::config::standard()).unwrap();
+        bincode::decode_from_slice(&mut buffer[..11], bincode::config::standard()).unwrap();
     assert_eq!(input, output);
-    assert_eq!(len, 10);
+    assert_eq!(len, 11);
 
     let mut buffer = [0u8; 32];
     let input: [u8; 1] = [1];

--- a/tests/issues/issue_474.rs
+++ b/tests/issues/issue_474.rs
@@ -62,7 +62,7 @@ impl MemCache {
     where
         T: Send + Sync + serde_incl::Serialize,
     {
-        let config = bincode::config::standard().write_fixed_array_length();
+        let config = bincode::config::standard();
         let mut guard = self.cache.write().unwrap();
 
         let encoded = bincode::serde::encode_to_vec(&cache_data, config)?;
@@ -76,7 +76,7 @@ impl MemCache {
     where
         T: Send + Sync + DeserializeOwned,
     {
-        let config = bincode::config::standard().write_fixed_array_length();
+        let config = bincode::config::standard();
         let guard = self.cache.read().unwrap();
         let cache_item = guard.get(key).unwrap();
         let (decoded, _len): (T, usize) =

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -24,17 +24,12 @@ fn test_serde_round_trip() {
     assert_eq!(result.b, 0);
 
     // validate bincode working
-    let bytes = bincode::encode_to_vec(
-        SerdeRoundtrip { a: 15, b: 15 },
-        bincode::config::standard().write_fixed_array_length(),
-    )
-    .unwrap();
+    let bytes =
+        bincode::encode_to_vec(SerdeRoundtrip { a: 15, b: 15 }, bincode::config::standard())
+            .unwrap();
     assert_eq!(bytes, &[15, 15]);
-    let (result, len): (SerdeRoundtrip, usize) = bincode::decode_from_slice(
-        &bytes,
-        bincode::config::standard().write_fixed_array_length(),
-    )
-    .unwrap();
+    let (result, len): (SerdeRoundtrip, usize) =
+        bincode::decode_from_slice(&bytes, bincode::config::standard()).unwrap();
     assert_eq!(result.a, 15);
     assert_eq!(result.b, 15);
     assert_eq!(len, 2);
@@ -66,28 +61,17 @@ fn test_serialize_deserialize_borrowed_data() {
     ];
 
     let mut result = [0u8; 20];
-    let len = bincode::serde::encode_into_slice(
-        &input,
-        &mut result,
-        bincode::config::standard().write_fixed_array_length(),
-    )
-    .unwrap();
+    let len = bincode::serde::encode_into_slice(&input, &mut result, bincode::config::standard())
+        .unwrap();
     let result = &result[..len];
     assert_eq!(result, expected);
 
-    let result = bincode::serde::encode_to_vec(
-        &input,
-        bincode::config::standard().write_fixed_array_length(),
-    )
-    .unwrap();
+    let result = bincode::serde::encode_to_vec(&input, bincode::config::standard()).unwrap();
 
     assert_eq!(result, expected);
 
-    let output: SerdeWithBorrowedData = bincode::serde::decode_borrowed_from_slice(
-        &result,
-        bincode::config::standard().write_fixed_array_length(),
-    )
-    .unwrap();
+    let output: SerdeWithBorrowedData =
+        bincode::serde::decode_borrowed_from_slice(&result, bincode::config::standard()).unwrap();
     assert_eq!(
         SerdeWithBorrowedData {
             b: 0, // remember: b is skipped
@@ -123,28 +107,17 @@ fn test_serialize_deserialize_owned_data() {
     ];
 
     let mut result = [0u8; 20];
-    let len = bincode::serde::encode_into_slice(
-        &input,
-        &mut result,
-        bincode::config::standard().write_fixed_array_length(),
-    )
-    .unwrap();
+    let len = bincode::serde::encode_into_slice(&input, &mut result, bincode::config::standard())
+        .unwrap();
     let result = &result[..len];
     assert_eq!(result, expected);
 
-    let result = bincode::serde::encode_to_vec(
-        &input,
-        bincode::config::standard().write_fixed_array_length(),
-    )
-    .unwrap();
+    let result = bincode::serde::encode_to_vec(&input, bincode::config::standard()).unwrap();
 
     assert_eq!(result, expected);
 
-    let (output, len): (SerdeWithOwnedData, usize) = bincode::serde::decode_from_slice(
-        &result,
-        bincode::config::standard().write_fixed_array_length(),
-    )
-    .unwrap();
+    let (output, len): (SerdeWithOwnedData, usize) =
+        bincode::serde::decode_from_slice(&result, bincode::config::standard()).unwrap();
     assert_eq!(
         SerdeWithOwnedData {
             b: 0, // remember: b is skipped
@@ -188,19 +161,12 @@ mod derive {
             T: bincode::Encode + bincode::Decode + PartialEq + core::fmt::Debug,
         {
             let mut slice = [0u8; 100];
-            let len = bincode::encode_into_slice(
-                &start,
-                &mut slice,
-                bincode::config::standard().write_fixed_array_length(),
-            )
-            .unwrap();
+            let len = bincode::encode_into_slice(&start, &mut slice, bincode::config::standard())
+                .unwrap();
             assert_eq!(len, expected_len);
             let slice = &slice[..len];
-            let (result, len): (T, usize) = bincode::decode_from_slice(
-                &slice,
-                bincode::config::standard().write_fixed_array_length(),
-            )
-            .unwrap();
+            let (result, len): (T, usize) =
+                bincode::decode_from_slice(&slice, bincode::config::standard()).unwrap();
 
             assert_eq!(start, result);
             assert_eq!(len, expected_len);

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -86,32 +86,28 @@ where
         &element,
         bincode::config::standard()
             .with_little_endian()
-            .with_fixed_int_encoding()
-            .write_fixed_array_length(),
+            .with_fixed_int_encoding(),
         &cmp,
     );
     the_same_with_config(
         &element,
         bincode::config::standard()
             .with_big_endian()
-            .with_fixed_int_encoding()
-            .write_fixed_array_length(),
+            .with_fixed_int_encoding(),
         &cmp,
     );
     the_same_with_config(
         &element,
         bincode::config::standard()
             .with_little_endian()
-            .with_variable_int_encoding()
-            .write_fixed_array_length(),
+            .with_variable_int_encoding(),
         &cmp,
     );
     the_same_with_config(
         &element,
         bincode::config::standard()
             .with_big_endian()
-            .with_variable_int_encoding()
-            .write_fixed_array_length(),
+            .with_variable_int_encoding(),
         &cmp,
     );
 }


### PR DESCRIPTION
This will help with confusion when people are using `bincode::serde::` as `bincode::config::standard()` won't give a runtime error.