### PR TITLE
Add zoxide under Bincode in the Wild

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ library.
 * [google/tarpc](https://github.com/google/tarpc): Bincode is used to serialize and deserialize networked RPC messages.
 * [servo/webrender](https://github.com/servo/webrender): Bincode records WebRender API calls for record/replay-style graphics debugging.
 * [servo/ipc-channel](https://github.com/servo/ipc-channel): IPC-Channel uses Bincode to send structs between processes using a channel-like API.
+* [ajeetdsouza/zoxide](https://github.com/ajeetdsouza/zoxide): zoxide uses Bincode to store a database of directories and their access frequencies on disk.
 
 ## Example
 


### PR DESCRIPTION
Hey, [zoxide](https://github.com/ajeetdsouza/zoxide) seems to be a different use of Bincode from the ones mentioned in the README, so I thought you might like to include it here.

Since it's a shell plugin, I decided to optimize for performance as much as possible. zoxide has to store a rather small database, so Bincode becomes a really good choice -- at that size, it's significantly faster than SQLite as well as a couple of other binary formats I tested against.