### PR TITLE
Added `std::error::Error::source`

### DIFF
--- a/src/de/impls.rs
+++ b/src/de/impls.rs
@@ -422,7 +422,7 @@ impl<'a, 'de: 'a> BorrowDecode<'de> for Option<&'a [u8]> {
 impl<'a, 'de: 'a> BorrowDecode<'de> for &'a str {
     fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let slice = <&[u8]>::borrow_decode(decoder)?;
-        core::str::from_utf8(slice).map_err(DecodeError::Utf8)
+        core::str::from_utf8(slice).map_err(|inner| DecodeError::Utf8 { inner })
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,7 +30,7 @@ pub enum EncodeError {
     #[cfg(feature = "std")]
     Io {
         /// The encountered error
-        error: std::io::Error,
+        inner: std::io::Error,
         /// The amount of bytes that were written before the error occurred
         index: usize,
     },
@@ -107,7 +107,10 @@ pub enum DecodeError {
     },
 
     /// The decoder tried to decode a `str`, but an utf8 error was encountered.
-    Utf8(core::str::Utf8Error),
+    Utf8 {
+        /// The inner error
+        inner: core::str::Utf8Error,
+    },
 
     /// The decoder tried to decode a `char` and failed. The given buffer contains the bytes that are read at the moment of failure.
     InvalidCharEncoding([u8; 4]),

--- a/src/features/impl_alloc.rs
+++ b/src/features/impl_alloc.rs
@@ -217,7 +217,9 @@ where
 impl Decode for String {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
         let bytes = Vec::<u8>::decode(decoder)?;
-        String::from_utf8(bytes).map_err(|e| DecodeError::Utf8(e.utf8_error()))
+        String::from_utf8(bytes).map_err(|e| DecodeError::Utf8 {
+            inner: e.utf8_error(),
+        })
     }
 }
 


### PR DESCRIPTION
Closes #528 

Also made the error naming scheme more consistent