### PR TITLE
Switched to weak dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,12 +85,12 @@
             "alloc,derive",
             "std",
             "std,derive",
-            "serde_no_std",
-            "serde_alloc",
             "serde",
-            "serde_no_std,derive",
-            "serde_alloc,derive",
-            "serde,derive"
+            "alloc,serde",
+            "std,serde",
+            "serde,derive",
+            "alloc,serde,derive",
+            "std,serde,derive",
           ]
         }
       },

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ derive = ["bincode_derive"]
 
 [dependencies]
 bincode_derive = { path = "derive", version = "2.0.0-rc.1", optional = true }
-serde = { package = "serde", version = "1.0", default-features = false, optional = true }
+serde = { version = "1.0", default-features = false, optional = true }
 
 # Used for tests
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,23 +25,14 @@ edition = "2021"
 
 [features]
 default = ["std", "derive", "atomic"]
-std = ["alloc"]
-alloc = []
+std = ["alloc", "serde?/std"]
+alloc = ["serde?/alloc"]
 atomic = []
 derive = ["bincode_derive"]
 
-# BlockedTODO: https://github.com/rust-lang/cargo/issues/8832
-# We want to enable these features automatically based on "alloc" or "std"
-#   std = ["alloc", "serde?/std"]
-#   alloc = ["serde?/alloc"]
-# now we have to do this hack:
-serde = ["serde_incl/std", "std", "serde_alloc"] # std
-serde_alloc = ["serde_incl/alloc", "alloc"] # alloc
-serde_no_std = ["serde_incl"] # no_std
-
 [dependencies]
 bincode_derive = { path = "derive", version = "2.0.0-rc.1", optional = true }
-serde_incl = { package = "serde", version = "1.0", default-features = false, optional = true }
+serde = { package = "serde", version = "1.0", default-features = false, optional = true }
 
 # Used for tests
 [dev-dependencies]

--- a/src/features/serde/de_borrowed.rs
+++ b/src/features/serde/de_borrowed.rs
@@ -5,7 +5,7 @@ use crate::{
     error::DecodeError,
 };
 use core::marker::PhantomData;
-use serde_incl::de::*;
+use serde::de::*;
 
 /// Decode a borrowed type from the given slice. Some parts of the decoded type are expected to be referring to the given slice
 pub fn decode_borrowed_from_slice<'de, T, C>(slice: &'de [u8], config: C) -> Result<T, DecodeError>
@@ -35,50 +35,50 @@ impl<'a, 'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'a, 'de
 
     fn deserialize_any<V>(self, _: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         Err(SerdeDecodeError::AnyNotSupported.into())
     }
 
     fn deserialize_bool<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_bool(Decode::decode(&mut self.de)?)
     }
 
     fn deserialize_i8<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_i8(Decode::decode(&mut self.de)?)
     }
 
     fn deserialize_i16<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_i16(Decode::decode(&mut self.de)?)
     }
 
     fn deserialize_i32<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_i32(Decode::decode(&mut self.de)?)
     }
 
     fn deserialize_i64<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_i64(Decode::decode(&mut self.de)?)
     }
 
-    serde_incl::serde_if_integer128! {
+    serde::serde_if_integer128! {
         fn deserialize_i128<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
         where
-            V: serde_incl::de::Visitor<'de>,
+            V: serde::de::Visitor<'de>,
         {
             visitor.visit_i128(Decode::decode(&mut self.de)?)
         }
@@ -86,36 +86,36 @@ impl<'a, 'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'a, 'de
 
     fn deserialize_u8<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_u8(Decode::decode(&mut self.de)?)
     }
 
     fn deserialize_u16<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_u16(Decode::decode(&mut self.de)?)
     }
 
     fn deserialize_u32<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_u32(Decode::decode(&mut self.de)?)
     }
 
     fn deserialize_u64<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_u64(Decode::decode(&mut self.de)?)
     }
 
-    serde_incl::serde_if_integer128! {
+    serde::serde_if_integer128! {
         fn deserialize_u128<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
         where
-            V: serde_incl::de::Visitor<'de>,
+            V: serde::de::Visitor<'de>,
         {
             visitor.visit_u128(Decode::decode(&mut self.de)?)
         }
@@ -123,28 +123,28 @@ impl<'a, 'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'a, 'de
 
     fn deserialize_f32<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_f32(Decode::decode(&mut self.de)?)
     }
 
     fn deserialize_f64<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_f64(Decode::decode(&mut self.de)?)
     }
 
     fn deserialize_char<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_char(Decode::decode(&mut self.de)?)
     }
 
     fn deserialize_str<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         let str = <&'de str>::borrow_decode(&mut self.de)?;
         visitor.visit_borrowed_str(str)
@@ -153,7 +153,7 @@ impl<'a, 'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'a, 'de
     #[cfg(not(feature = "alloc"))]
     fn deserialize_string<V>(self, _: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         Err(SerdeDecodeError::CannotBorrowOwnedData.into())
     }
@@ -161,14 +161,14 @@ impl<'a, 'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'a, 'de
     #[cfg(feature = "alloc")]
     fn deserialize_string<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_string(Decode::decode(&mut self.de)?)
     }
 
     fn deserialize_bytes<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         let bytes = <&'de [u8]>::borrow_decode(&mut self.de)?;
         visitor.visit_borrowed_bytes(bytes)
@@ -177,7 +177,7 @@ impl<'a, 'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'a, 'de
     #[cfg(not(feature = "alloc"))]
     fn deserialize_byte_buf<V>(self, _: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         Err(SerdeDecodeError::CannotBorrowOwnedData.into())
     }
@@ -185,14 +185,14 @@ impl<'a, 'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'a, 'de
     #[cfg(feature = "alloc")]
     fn deserialize_byte_buf<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_byte_buf(Decode::decode(&mut self.de)?)
     }
 
     fn deserialize_option<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         let variant = crate::de::decode_option_variant(&mut self.de, "Option<T>")?;
         if variant.is_some() {
@@ -204,7 +204,7 @@ impl<'a, 'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'a, 'de
 
     fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_unit()
     }
@@ -215,7 +215,7 @@ impl<'a, 'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'a, 'de
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_unit()
     }
@@ -226,14 +226,14 @@ impl<'a, 'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'a, 'de
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_newtype_struct(self)
     }
 
     fn deserialize_seq<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         let len = usize::decode(&mut self.de)?;
         self.deserialize_tuple(len, visitor)
@@ -241,7 +241,7 @@ impl<'a, 'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'a, 'de
 
     fn deserialize_tuple<V>(mut self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         struct Access<'a, 'b, 'de, DE: BorrowDecoder<'de>> {
             deserializer: &'a mut SerdeDecoder<'b, 'de, DE>,
@@ -288,14 +288,14 @@ impl<'a, 'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'a, 'de
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         self.deserialize_tuple(len, visitor)
     }
 
     fn deserialize_map<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         struct Access<'a, 'b, 'de, DE: BorrowDecoder<'de>> {
             deserializer: &'a mut SerdeDecoder<'b, 'de, DE>,
@@ -358,7 +358,7 @@ impl<'a, 'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'a, 'de
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         self.deserialize_tuple(fields.len(), visitor)
     }
@@ -370,21 +370,21 @@ impl<'a, 'de, DE: BorrowDecoder<'de>> Deserializer<'de> for SerdeDecoder<'a, 'de
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_enum(self)
     }
 
     fn deserialize_identifier<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         Err(SerdeDecodeError::IdentifierNotSupported.into())
     }
 
     fn deserialize_ignored_any<V>(self, _: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         Err(SerdeDecodeError::IgnoredAnyNotSupported.into())
     }

--- a/src/features/serde/de_owned.rs
+++ b/src/features/serde/de_owned.rs
@@ -4,7 +4,7 @@ use crate::{
     de::{read::Reader, Decode, Decoder},
     error::DecodeError,
 };
-use serde_incl::de::*;
+use serde::de::*;
 
 /// Decode an owned type from the given slice. Will return the decoded type `T` as well as the amount of bytes that were read.
 ///
@@ -69,50 +69,50 @@ impl<'a, 'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'a, DE> {
 
     fn deserialize_any<V>(self, _: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         Err(SerdeDecodeError::AnyNotSupported.into())
     }
 
     fn deserialize_bool<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_bool(Decode::decode(&mut self.de)?)
     }
 
     fn deserialize_i8<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_i8(Decode::decode(&mut self.de)?)
     }
 
     fn deserialize_i16<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_i16(Decode::decode(&mut self.de)?)
     }
 
     fn deserialize_i32<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_i32(Decode::decode(&mut self.de)?)
     }
 
     fn deserialize_i64<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_i64(Decode::decode(&mut self.de)?)
     }
 
-    serde_incl::serde_if_integer128! {
+    serde::serde_if_integer128! {
         fn deserialize_i128<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
         where
-            V: serde_incl::de::Visitor<'de>,
+            V: serde::de::Visitor<'de>,
         {
             visitor.visit_i128(Decode::decode(&mut self.de)?)
         }
@@ -120,36 +120,36 @@ impl<'a, 'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'a, DE> {
 
     fn deserialize_u8<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_u8(Decode::decode(&mut self.de)?)
     }
 
     fn deserialize_u16<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_u16(Decode::decode(&mut self.de)?)
     }
 
     fn deserialize_u32<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_u32(Decode::decode(&mut self.de)?)
     }
 
     fn deserialize_u64<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_u64(Decode::decode(&mut self.de)?)
     }
 
-    serde_incl::serde_if_integer128! {
+    serde::serde_if_integer128! {
         fn deserialize_u128<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
         where
-            V: serde_incl::de::Visitor<'de>,
+            V: serde::de::Visitor<'de>,
         {
             visitor.visit_u128(Decode::decode(&mut self.de)?)
         }
@@ -157,21 +157,21 @@ impl<'a, 'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'a, DE> {
 
     fn deserialize_f32<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_f32(Decode::decode(&mut self.de)?)
     }
 
     fn deserialize_f64<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_f64(Decode::decode(&mut self.de)?)
     }
 
     fn deserialize_char<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_char(Decode::decode(&mut self.de)?)
     }
@@ -179,7 +179,7 @@ impl<'a, 'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'a, DE> {
     #[cfg(feature = "alloc")]
     fn deserialize_str<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_string(Decode::decode(&mut self.de)?)
     }
@@ -187,7 +187,7 @@ impl<'a, 'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'a, DE> {
     #[cfg(not(feature = "alloc"))]
     fn deserialize_str<V>(self, _: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         Err(SerdeDecodeError::CannotBorrowOwnedData.into())
     }
@@ -195,7 +195,7 @@ impl<'a, 'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'a, DE> {
     #[cfg(feature = "alloc")]
     fn deserialize_string<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_string(Decode::decode(&mut self.de)?)
     }
@@ -203,7 +203,7 @@ impl<'a, 'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'a, DE> {
     #[cfg(not(feature = "alloc"))]
     fn deserialize_string<V>(self, _: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         Err(SerdeDecodeError::CannotAllocate.into())
     }
@@ -211,7 +211,7 @@ impl<'a, 'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'a, DE> {
     #[cfg(feature = "alloc")]
     fn deserialize_bytes<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_byte_buf(Decode::decode(&mut self.de)?)
     }
@@ -219,7 +219,7 @@ impl<'a, 'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'a, DE> {
     #[cfg(not(feature = "alloc"))]
     fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         Err(SerdeDecodeError::CannotBorrowOwnedData.into())
     }
@@ -227,21 +227,21 @@ impl<'a, 'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'a, DE> {
     #[cfg(feature = "alloc")]
     fn deserialize_byte_buf<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_byte_buf(Decode::decode(&mut self.de)?)
     }
     #[cfg(not(feature = "alloc"))]
     fn deserialize_byte_buf<V>(self, _: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         Err(SerdeDecodeError::CannotAllocate.into())
     }
 
     fn deserialize_option<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         let variant = crate::de::decode_option_variant(&mut self.de, "Option<T>")?;
         if variant.is_some() {
@@ -253,7 +253,7 @@ impl<'a, 'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'a, DE> {
 
     fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_unit()
     }
@@ -264,7 +264,7 @@ impl<'a, 'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'a, DE> {
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_unit()
     }
@@ -275,14 +275,14 @@ impl<'a, 'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'a, DE> {
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_newtype_struct(self)
     }
 
     fn deserialize_seq<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         let len = usize::decode(&mut self.de)?;
         self.deserialize_tuple(len, visitor)
@@ -290,7 +290,7 @@ impl<'a, 'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'a, DE> {
 
     fn deserialize_tuple<V>(mut self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         struct Access<'a, 'b, DE: Decoder> {
             deserializer: &'a mut SerdeDecoder<'b, DE>,
@@ -336,14 +336,14 @@ impl<'a, 'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'a, DE> {
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         self.deserialize_tuple(len, visitor)
     }
 
     fn deserialize_map<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         struct Access<'a, 'b, DE: Decoder> {
             deserializer: &'a mut SerdeDecoder<'b, DE>,
@@ -404,7 +404,7 @@ impl<'a, 'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'a, DE> {
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         self.deserialize_tuple(fields.len(), visitor)
     }
@@ -416,21 +416,21 @@ impl<'a, 'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'a, DE> {
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         visitor.visit_enum(self)
     }
 
     fn deserialize_identifier<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         Err(SerdeDecodeError::IdentifierNotSupported.into())
     }
 
     fn deserialize_ignored_any<V>(self, _: V) -> Result<V::Value, Self::Error>
     where
-        V: serde_incl::de::Visitor<'de>,
+        V: serde::de::Visitor<'de>,
     {
         Err(SerdeDecodeError::IgnoredAnyNotSupported.into())
     }

--- a/src/features/serde/mod.rs
+++ b/src/features/serde/mod.rs
@@ -18,7 +18,6 @@
 //! # use bincode::{Decode, Encode};
 //! # use serde_derive::{Deserialize, Serialize};
 //! #[derive(Serialize, Deserialize)]
-//! # #[serde(crate = "serde_incl")]
 //! pub struct SerdeType {
 //!     // ...
 //! }
@@ -102,7 +101,7 @@ pub enum DecodeError {
 }
 
 #[cfg(feature = "alloc")]
-impl serde_incl::de::Error for crate::error::DecodeError {
+impl serde::de::Error for crate::error::DecodeError {
     fn custom<T>(msg: T) -> Self
     where
         T: core::fmt::Display,
@@ -113,10 +112,10 @@ impl serde_incl::de::Error for crate::error::DecodeError {
 }
 
 #[cfg(not(feature = "std"))]
-impl serde_incl::de::StdError for crate::error::DecodeError {}
+impl serde::de::StdError for crate::error::DecodeError {}
 
 #[cfg(not(feature = "alloc"))]
-impl serde_incl::de::Error for crate::error::DecodeError {
+impl serde::de::Error for crate::error::DecodeError {
     fn custom<T>(_: T) -> Self
     where
         T: core::fmt::Display,
@@ -159,7 +158,7 @@ impl Into<crate::error::EncodeError> for EncodeError {
 }
 
 #[cfg(feature = "alloc")]
-impl serde_incl::ser::Error for crate::error::EncodeError {
+impl serde::ser::Error for crate::error::EncodeError {
     fn custom<T>(msg: T) -> Self
     where
         T: core::fmt::Display,
@@ -171,10 +170,10 @@ impl serde_incl::ser::Error for crate::error::EncodeError {
 }
 
 #[cfg(not(feature = "std"))]
-impl serde_incl::de::StdError for crate::error::EncodeError {}
+impl serde::de::StdError for crate::error::EncodeError {}
 
 #[cfg(not(feature = "alloc"))]
-impl serde_incl::ser::Error for crate::error::EncodeError {
+impl serde::ser::Error for crate::error::EncodeError {
     fn custom<T>(_: T) -> Self
     where
         T: core::fmt::Display,
@@ -195,7 +194,7 @@ pub struct Compat<T>(pub T);
 
 impl<T> crate::Decode for Compat<T>
 where
-    T: serde_incl::de::DeserializeOwned,
+    T: serde::de::DeserializeOwned,
 {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         let serde_decoder = de_owned::SerdeDecoder { de: decoder };
@@ -205,7 +204,7 @@ where
 
 impl<T> crate::Encode for Compat<T>
 where
-    T: serde_incl::Serialize,
+    T: serde::Serialize,
 {
     fn encode<E: crate::enc::Encoder>(
         &self,
@@ -227,7 +226,7 @@ pub struct BorrowCompat<T>(pub T);
 
 impl<'de, T> crate::de::BorrowDecode<'de> for BorrowCompat<T>
 where
-    T: serde_incl::de::Deserialize<'de>,
+    T: serde::de::Deserialize<'de>,
 {
     fn borrow_decode<D: crate::de::BorrowDecoder<'de>>(
         decoder: &mut D,
@@ -242,7 +241,7 @@ where
 
 impl<T> crate::Encode for BorrowCompat<T>
 where
-    T: serde_incl::Serialize,
+    T: serde::Serialize,
 {
     fn encode<E: crate::enc::Encoder>(
         &self,

--- a/src/features/serde/mod.rs
+++ b/src/features/serde/mod.rs
@@ -39,14 +39,6 @@
 //! # }
 //! ```
 //!
-//! # `alloc` and `no_std`
-//!
-//! The `serde` feature enables both `alloc` and `std` at this point in time.
-//! To use bincode and serde on no_std targets, try one of the following features:
-//!
-//! - `serde_alloc`: enables `serde` and `alloc`
-//! - `serde_no_std`: enables `serde` without `alloc` or `std`
-//!
 //! # Known issues
 //!
 //! Currently the `serde` feature will automatically enable the `alloc` and `std` feature. If you're running in a `#[no_std]` environment consider using bincode's own derive macros.

--- a/src/features/serde/ser.rs
+++ b/src/features/serde/ser.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
-use serde_incl::ser::*;
+use serde::ser::*;
 
 #[cfg(feature = "alloc")]
 /// Encode a `serde` `Serialize` type into a `Vec<u8>` with the bincode algorithm
@@ -121,7 +121,7 @@ where
         v.encode(self.enc)
     }
 
-    serde_incl::serde_if_integer128! {
+    serde::serde_if_integer128! {
         fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
             v.encode(self.enc)
         }
@@ -143,7 +143,7 @@ where
         v.encode(self.enc)
     }
 
-    serde_incl::serde_if_integer128! {
+    serde::serde_if_integer128! {
         fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
             v.encode(self.enc)
         }

--- a/tests/issues/issue_474.rs
+++ b/tests/issues/issue_474.rs
@@ -3,19 +3,17 @@
 extern crate std;
 
 use chrono::{DateTime, Utc};
-use serde_incl::de::DeserializeOwned;
+use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 use std::prelude::rust_2021::*;
 use uuid::Uuid;
 
 #[derive(serde_derive::Serialize, serde_derive::Deserialize, PartialEq, Debug)]
-#[serde(crate = "serde_incl")]
 pub struct MyStruct {
     name: String,
 }
 
 #[derive(serde_derive::Serialize, serde_derive::Deserialize, PartialEq, Debug)]
-#[serde(crate = "serde_incl")]
 pub struct CustomerTest {
     pub id: Option<Uuid>,
     pub email_address: Option<String>,
@@ -60,7 +58,7 @@ impl MemCache {
         expire_seconds: i64,
     ) -> Result<(), bincode::error::EncodeError>
     where
-        T: Send + Sync + serde_incl::Serialize,
+        T: Send + Sync + serde::Serialize,
     {
         let config = bincode::config::standard();
         let mut guard = self.cache.write().unwrap();

--- a/tests/issues/issue_500.rs
+++ b/tests/issues/issue_500.rs
@@ -14,7 +14,6 @@ use std::collections::BTreeSet;
     Debug,
     PartialEq,
 )]
-#[serde(crate = "serde_incl")]
 pub struct Membership {
     /// learners set
     learners: BTreeSet<NodeId>,

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -6,7 +6,6 @@ use alloc::string::String;
 use serde_derive::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, bincode::Encode, bincode::Decode)]
-#[serde(crate = "serde_incl")]
 pub struct SerdeRoundtrip {
     pub a: u32,
     #[serde(skip)]
@@ -36,7 +35,6 @@ fn test_serde_round_trip() {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
-#[serde(crate = "serde_incl")]
 pub struct SerdeWithBorrowedData<'a> {
     pub a: u32,
     #[serde(skip)]
@@ -82,7 +80,6 @@ fn test_serialize_deserialize_borrowed_data() {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
-#[serde(crate = "serde_incl")]
 pub struct SerdeWithOwnedData {
     pub a: u32,
     #[serde(skip)]
@@ -134,7 +131,6 @@ mod derive {
     use serde_derive::{Deserialize, Serialize};
 
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
-    #[serde(crate = "serde_incl")]
     pub struct SerdeType {
         pub a: u32,
     }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -116,8 +116,8 @@ where
 pub trait TheSameTrait:
     bincode::Encode
     + bincode::Decode
-    + serde_incl::de::DeserializeOwned
-    + serde_incl::Serialize
+    + serde::de::DeserializeOwned
+    + serde::Serialize
     + Debug
     + 'static
 {
@@ -126,8 +126,8 @@ pub trait TheSameTrait:
 impl<T> TheSameTrait for T where
     T: bincode::Encode
         + bincode::Decode
-        + serde_incl::de::DeserializeOwned
-        + serde_incl::Serialize
+        + serde::de::DeserializeOwned
+        + serde::Serialize
         + Debug
         + 'static
 {

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -27,7 +27,7 @@ where
     );
     assert_eq!(len, decoded_len);
 
-    #[cfg(feature = "serde")]
+    #[cfg(all(feature = "serde", feature = "alloc"))]
     // skip_fixed_array_length is not supposed on serde
     if !C::SKIP_FIXED_ARRAY_LENGTH {
         let encoded = bincode::serde::encode_to_vec(&element, config).unwrap();

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -114,12 +114,7 @@ where
 
 #[cfg(feature = "serde")]
 pub trait TheSameTrait:
-    bincode::Encode
-    + bincode::Decode
-    + serde::de::DeserializeOwned
-    + serde::Serialize
-    + Debug
-    + 'static
+    bincode::Encode + bincode::Decode + serde::de::DeserializeOwned + serde::Serialize + Debug + 'static
 {
 }
 #[cfg(feature = "serde")]


### PR DESCRIPTION
Rust 1.60 now has weak dependencies, meaning we don't have to do our serde hack any more.

Closes #472 