### PR TITLE
Fix cross platform tests

### DIFF
--- a/.github/workflows/cross_platform.yml
+++ b/.github/workflows/cross_platform.yml
@@ -128,7 +128,9 @@
         "fail-fast": false,
         "matrix": {
           "platform": [
-            "i686-pc-windows-gnu",
+            # linker `i686-w64-mingw32-gcc` not found
+            # "i686-pc-windows-gnu",
+
             "x86_64-pc-windows-gnu",
           ]
         }

--- a/.github/workflows/cross_platform.yml
+++ b/.github/workflows/cross_platform.yml
@@ -74,7 +74,12 @@
             # "wasm32-unknown-emscripten",
 
             "x86_64-linux-android",
-            "x86_64-sun-solaris",
+
+            # Seems to not be able to link to certain files
+            # - cannot find -lsendfile
+            # - cannot find -llgrp
+            # "x86_64-sun-solaris",
+
             "x86_64-unknown-linux-gnu",
             "x86_64-unknown-linux-musl",
 

--- a/.github/workflows/cross_platform.yml
+++ b/.github/workflows/cross_platform.yml
@@ -34,7 +34,11 @@
             "armv7-linux-androideabi",
             "armv7-unknown-linux-gnueabihf",
             "armv7-unknown-linux-musleabihf",
-            "asmjs-unknown-emscripten",
+
+            # BlockedTODO: https://github.com/chronotope/chrono/issues/674
+            # Fixed in https://github.com/chronotope/chrono/pull/593
+            # "asmjs-unknown-emscripten",
+
             "i586-unknown-linux-gnu",
             "i586-unknown-linux-musl",
             "i686-linux-android",
@@ -47,21 +51,38 @@
             "mipsel-unknown-linux-gnu",
             "mipsel-unknown-linux-musl",
             "powerpc-unknown-linux-gnu",
-            "powerpc64le-unknown-linux-gnu",
+
+            # Seems to have a bug in qemu, where all floats are `0.0` and aren't equal with each other
+            # "powerpc64le-unknown-linux-gnu",
+
             "riscv64gc-unknown-linux-gnu",
             "s390x-unknown-linux-gnu",
-            "sparcv9-sun-solaris",
-            "thumbv6m-none-eabi",
-            "thumbv7em-none-eabi",
-            "thumbv7em-none-eabihf",
-            "thumbv7m-none-eabi",
-            "wasm32-unknown-emscripten",
+
+            # Seems to not be able to link to certain files
+            # - cannot find -lsendfile
+            # - cannot find -llgrp
+            # "sparcv9-sun-solaris",
+
+            # These have no `std`
+            # "thumbv6m-none-eabi",
+            # "thumbv7em-none-eabi",
+            # "thumbv7em-none-eabihf",
+            # "thumbv7m-none-eabi",
+
+            # BlockedTODO: https://github.com/chronotope/chrono/issues/674
+            # Fixed in https://github.com/chronotope/chrono/pull/593
+            # "wasm32-unknown-emscripten",
+
             "x86_64-linux-android",
             "x86_64-pc-windows-gnu",
             "x86_64-sun-solaris",
             "x86_64-unknown-linux-gnu",
             "x86_64-unknown-linux-musl",
-            "x86_64-unknown-netbsd",
+
+            # Seems to immediately bail
+            # error: test failed, to rerun pass '--lib'
+            # could not execute process `...` (never executed)
+            # "x86_64-unknown-netbsd",
           ]
         }
       },
@@ -90,7 +111,8 @@
           "run": "cross test --target ${{ matrix.platform }}",
           "name": "Run tests",
           "env": {
-            "RUSTFLAGS": "-D warnings"
+            "RUSTFLAGS": "-D warnings",
+            "RUST_BACKTRACE": "1",
           }
         }
       ]

--- a/.github/workflows/cross_platform.yml
+++ b/.github/workflows/cross_platform.yml
@@ -74,7 +74,6 @@
             # "wasm32-unknown-emscripten",
 
             "x86_64-linux-android",
-            "x86_64-pc-windows-gnu",
             "x86_64-sun-solaris",
             "x86_64-unknown-linux-gnu",
             "x86_64-unknown-linux-musl",

--- a/.github/workflows/cross_platform.yml
+++ b/.github/workflows/cross_platform.yml
@@ -16,32 +16,52 @@
     }
   },
   "jobs": {
-    "check": {
-      "name": "Test",
+    "test_cross": {
+      "name": "Cross platform test",
       "runs-on": "ubuntu-latest",
       "strategy": {
         "fail-fast": false,
         "matrix": {
           "platform": [
-            "aarch64-unknown-linux-gnu",
+            "aarch64-unknown-linux-musl",
+            "arm-linux-androideabi",
             "arm-unknown-linux-gnueabi",
             "arm-unknown-linux-gnueabihf",
-            # "armv5te-unknown-linux-gnueabi",
+            "arm-unknown-linux-musleabi",
+            "arm-unknown-linux-musleabihf",
+            "armv5te-unknown-linux-gnueabi",
+            "armv5te-unknown-linux-musleabi",
+            "armv7-linux-androideabi",
             "armv7-unknown-linux-gnueabihf",
+            "armv7-unknown-linux-musleabihf",
+            "asmjs-unknown-emscripten",
             "i586-unknown-linux-gnu",
-            # "i686-pc-windows-gnu",
+            "i586-unknown-linux-musl",
+            "i686-linux-android",
             "i686-unknown-linux-gnu",
-            # "mips-unknown-linux-gnu",
+            "i686-unknown-linux-musl",
+            "mips-unknown-linux-gnu",
+            "mips-unknown-linux-musl",
             "mips64-unknown-linux-gnuabi64",
             "mips64el-unknown-linux-gnuabi64",
-            # "mipsel-unknown-linux-gnu",
-            # "powerpc-unknown-linux-gnu",
-            # "powerpc64-unknown-linux-gnu",
-            # "powerpc64le-unknown-linux-gnu",
+            "mipsel-unknown-linux-gnu",
+            "mipsel-unknown-linux-musl",
+            "powerpc-unknown-linux-gnu",
+            "powerpc64le-unknown-linux-gnu",
             "riscv64gc-unknown-linux-gnu",
-            # "sparc64-unknown-linux-gnu",
+            "s390x-unknown-linux-gnu",
+            "sparcv9-sun-solaris",
+            "thumbv6m-none-eabi",
+            "thumbv7em-none-eabi",
+            "thumbv7em-none-eabihf",
+            "thumbv7m-none-eabi",
+            "wasm32-unknown-emscripten",
+            "x86_64-linux-android",
             "x86_64-pc-windows-gnu",
-            "x86_64-unknown-linux-gnu"
+            "x86_64-sun-solaris",
+            "x86_64-unknown-linux-gnu",
+            "x86_64-unknown-linux-musl",
+            "x86_64-unknown-netbsd",
           ]
         }
       },
@@ -68,6 +88,42 @@
         },
         {
           "run": "cross test --target ${{ matrix.platform }}",
+          "name": "Run tests",
+          "env": {
+            "RUSTFLAGS": "-D warnings"
+          }
+        }
+      ]
+    },
+    "test_windows": {
+      "name": "Cross platform test",
+      "runs-on": "windows-latest",
+      "strategy": {
+        "fail-fast": false,
+        "matrix": {
+          "platform": [
+            "i686-pc-windows-gnu",
+            "x86_64-pc-windows-gnu",
+          ]
+        }
+      },
+      "steps": [
+        {
+          "uses": "actions/checkout@v2",
+          "name": "Checkout"
+        },
+        {
+          "uses": "actions-rs/toolchain@v1",
+          "with": {
+            "profile": "minimal",
+            "toolchain": "stable",
+            "target": "${{ matrix.platform }}",
+            "override": true
+          },
+          "name": "Install Rust stable"
+        },
+        {
+          "run": "cargo test --target ${{ matrix.platform }}",
           "name": "Run tests",
           "env": {
             "RUSTFLAGS": "-D warnings"

--- a/tests/basic_types.rs
+++ b/tests/basic_types.rs
@@ -4,7 +4,7 @@ use core::cell::{Cell, RefCell};
 use core::ops::Bound;
 use core::time::Duration;
 use std::num::*;
-use utils::the_same;
+use utils::{the_same, the_same_with_comparer};
 
 #[test]
 fn test_numbers() {
@@ -23,8 +23,9 @@ fn test_numbers() {
     the_same(5i128);
     the_same(5isize);
 
-    the_same(5.0f32);
-    the_same(5.0f64);
+    println!("Test {:?}", 5.0f32);
+    the_same_with_comparer(5.0f32, |a, b| (a - b).abs() <= f32::EPSILON);
+    the_same_with_comparer(5.0f64, |a, b| (a - b).abs() <= f64::EPSILON);
 
     // bool
     the_same(true);


### PR DESCRIPTION
This PR updates the list of targets being tested to match cross 0.2.1 (the current latest version). Previously the list was based on `main`, and a lot of the targets simply didn't exist.

Some of the targets are commented out because they simply don't build. Bincode passes all tests on all targets that successfully build.

`powerpc64le-unknown-linux-gnu` technically builds but fails the test, but this is soley because of a bug in floating points on qemu, where all `f32` and `f64` values are `0.0` and aren't equal to each other.  https://github.com/cross-rs/cross/issues/644