### PR TITLE
Add impl Encode for [T], where T: Encode

### DIFF
--- a/src/enc/impls.rs
+++ b/src/enc/impls.rs
@@ -283,10 +283,13 @@ impl Encode for char {
     }
 }
 
+// BlockedTODO: https://github.com/rust-lang/rust/issues/37653
+//
+// We'll want to implement encoding for both &[u8] and &[T: Encode],
+// but those implementations overlap because u8 also implements Encode
 // impl Encode for &'_ [u8] {
 //     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
-//         super::encode_slice_len(encoder, self.len())?;
-//         encoder.writer().write(self)
+//         encoder.writer().write(*self)
 //     }
 // }
 

--- a/src/enc/impls.rs
+++ b/src/enc/impls.rs
@@ -290,6 +290,19 @@ impl Encode for char {
 //     }
 // }
 
+impl<T> Encode for [T]
+where
+    T: Encode,
+{
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        super::encode_slice_len(encoder, self.len())?;
+        for item in self {
+            item.encode(encoder)?;
+        }
+        Ok(())
+    }
+}
+
 const TAG_CONT: u8 = 0b1000_0000;
 const TAG_TWO_B: u8 = 0b1100_0000;
 const TAG_THREE_B: u8 = 0b1110_0000;

--- a/src/enc/impls.rs
+++ b/src/enc/impls.rs
@@ -337,26 +337,6 @@ fn encode_utf8(writer: &mut impl Writer, c: char) -> Result<(), EncodeError> {
     }
 }
 
-// BlockedTODO: https://github.com/rust-lang/rust/issues/37653
-//
-// We'll want to implement encoding for both &[u8] and &[T: Encode],
-// but those implementations overlap because u8 also implements Encode
-// impl Encode for &'_ [u8] {
-//     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
-//         encoder.writer().write(*self)
-//     }
-// }
-
-impl<T: Encode> Encode for &'_ [T] {
-    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
-        self.len().encode(encoder)?;
-        for item in self.iter() {
-            item.encode(encoder)?;
-        }
-        Ok(())
-    }
-}
-
 impl Encode for str {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
         self.as_bytes().encode(encoder)

--- a/src/features/impl_alloc.rs
+++ b/src/features/impl_alloc.rs
@@ -375,19 +375,6 @@ where
     }
 }
 
-impl<T> Encode for Box<[T]>
-where
-    T: Encode,
-{
-    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
-        crate::enc::encode_slice_len(encoder, self.len())?;
-        for item in self.iter() {
-            item.encode(encoder)?;
-        }
-        Ok(())
-    }
-}
-
 impl<'cow, T> Decode for Cow<'cow, T>
 where
     T: ToOwned + ?Sized,


### PR DESCRIPTION
Since Encode takes a reference, this allows us to encode &[T] directly
using this implementation. The encoding scheme is the same as for
Vec<T>.

This also makes the implementation for &[u8] superfluous, since we get
an implementation for [u8] by virtue of u8 implementing encode. This
also gives us free implementations for &[u16], &[u32], etc. which is
quite useful. Nonetheless, we keep the implementation for &[u8] around,
because the implementation can directly write a large number of bytes,
which can be more efficient than the generic implementation.

And uh, apologies if you would have preferred I raise an issue first, but this felt like a small enough change to warrant a direct PR.

I actually ran into a situation where this was convenient. My workaround to not having this was to take `&Vec<T>` as an argument to my function, and this seemed highly unidiomatic. I was also surprised not to see this when digging around in the docs the other day.