### PR TITLE
Shrink `DecodeError` from 48 to 32 bytes on 64-bit arch

### DIFF
--- a/derive/src/derive_enum.rs
+++ b/derive/src/derive_enum.rs
@@ -185,7 +185,7 @@ impl DeriveEnum {
                 if self.variants.iter().any(|i| i.has_fixed_value()) {
                     // we have fixed values, implement AllowedEnumVariants::Allowed
                     variant_inner.push_parsed(format!(
-                        "{}::error::AllowedEnumVariants::Allowed",
+                        "&{}::error::AllowedEnumVariants::Allowed",
                         crate_name
                     ))?;
                     variant_inner.group(Delimiter::Parenthesis, |allowed_inner| {
@@ -204,7 +204,7 @@ impl DeriveEnum {
                 } else {
                     // no fixed values, implement a range
                     variant_inner.push_parsed(format!(
-                        "{0}::error::AllowedEnumVariants::Range {{ min: 0, max: {1} }}",
+                        "&{0}::error::AllowedEnumVariants::Range {{ min: 0, max: {1} }}",
                         crate_name,
                         self.variants.len() - 1
                     ))?;

--- a/src/de/impls.rs
+++ b/src/de/impls.rs
@@ -607,7 +607,7 @@ where
             }
             x => Err(DecodeError::UnexpectedVariant {
                 found: x as u32,
-                allowed: crate::error::AllowedEnumVariants::Range { max: 1, min: 0 },
+                allowed: &crate::error::AllowedEnumVariants::Range { max: 1, min: 0 },
                 type_name: core::any::type_name::<Result<T, U>>(),
             }),
         }
@@ -632,7 +632,7 @@ where
             }
             x => Err(DecodeError::UnexpectedVariant {
                 found: x as u32,
-                allowed: crate::error::AllowedEnumVariants::Range { max: 1, min: 0 },
+                allowed: &crate::error::AllowedEnumVariants::Range { max: 1, min: 0 },
                 type_name: core::any::type_name::<Result<T, U>>(),
             }),
         }
@@ -745,7 +745,7 @@ where
             1 => Ok(Bound::Included(T::decode(decoder)?)),
             2 => Ok(Bound::Excluded(T::decode(decoder)?)),
             x => Err(DecodeError::UnexpectedVariant {
-                allowed: crate::error::AllowedEnumVariants::Range { max: 2, min: 0 },
+                allowed: &crate::error::AllowedEnumVariants::Range { max: 2, min: 0 },
                 found: x,
                 type_name: core::any::type_name::<Bound<T>>(),
             }),
@@ -763,7 +763,7 @@ where
             1 => Ok(Bound::Included(T::borrow_decode(decoder)?)),
             2 => Ok(Bound::Excluded(T::borrow_decode(decoder)?)),
             x => Err(DecodeError::UnexpectedVariant {
-                allowed: crate::error::AllowedEnumVariants::Range { max: 2, min: 0 },
+                allowed: &crate::error::AllowedEnumVariants::Range { max: 2, min: 0 },
                 found: x,
                 type_name: core::any::type_name::<Bound<T>>(),
             }),

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -265,7 +265,7 @@ pub(crate) fn decode_option_variant<D: Decoder>(
         1 => Ok(Some(())),
         x => Err(DecodeError::UnexpectedVariant {
             found: x as u32,
-            allowed: crate::error::AllowedEnumVariants::Range { max: 1, min: 0 },
+            allowed: &crate::error::AllowedEnumVariants::Range { max: 1, min: 0 },
             type_name,
         }),
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,7 +48,7 @@ pub enum EncodeError {
         /// The error that was thrown by the SystemTime
         inner: std::time::SystemTimeError,
         /// The SystemTime that caused the error
-        time: std::time::SystemTime,
+        time: std::boxed::Box<std::time::SystemTime>,
     },
 
     #[cfg(feature = "serde")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -160,7 +160,7 @@ pub enum DecodeError {
     /// The decoder tried to decode a `CString`, but the incoming data contained a 0 byte
     #[cfg(feature = "std")]
     CStringNulError {
-        /// Null byte position
+        /// Nul byte position
         position: usize,
     },
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -100,7 +100,7 @@ pub enum DecodeError {
         type_name: &'static str,
 
         /// The variants that are allowed
-        allowed: AllowedEnumVariants,
+        allowed: &'static AllowedEnumVariants,
 
         /// The index of the enum that the decoder encountered
         found: u32,
@@ -160,8 +160,8 @@ pub enum DecodeError {
     /// The decoder tried to decode a `CString`, but the incoming data contained a 0 byte
     #[cfg(feature = "std")]
     CStringNulError {
-        /// The inner exception
-        inner: std::ffi::NulError,
+        /// Null byte position
+        position: usize,
     },
 
     /// An uncommon error occurred, see the inner text for more information

--- a/src/features/impl_std.rs
+++ b/src/features/impl_std.rs
@@ -144,7 +144,9 @@ impl Encode for CString {
 impl Decode for CString {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
         let vec = std::vec::Vec::decode(decoder)?;
-        CString::new(vec).map_err(|inner| DecodeError::CStringNulError { position: inner.nul_position() })
+        CString::new(vec).map_err(|inner| DecodeError::CStringNulError {
+            position: inner.nul_position(),
+        })
     }
 }
 impl_borrow_decode!(CString);

--- a/src/features/impl_std.rs
+++ b/src/features/impl_std.rs
@@ -218,7 +218,7 @@ impl Encode for SystemTime {
         let duration = self.duration_since(SystemTime::UNIX_EPOCH).map_err(|e| {
             EncodeError::InvalidSystemTime {
                 inner: e,
-                time: *self,
+                time: std::boxed::Box::new(*self),
             }
         })?;
         duration.encode(encoder)

--- a/src/features/impl_std.rs
+++ b/src/features/impl_std.rs
@@ -144,7 +144,7 @@ impl Encode for CString {
 impl Decode for CString {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
         let vec = std::vec::Vec::decode(decoder)?;
-        CString::new(vec).map_err(|inner| DecodeError::CStringNulError { inner })
+        CString::new(vec).map_err(|inner| DecodeError::CStringNulError { position: inner.nul_position() })
     }
 }
 impl_borrow_decode!(CString);
@@ -285,7 +285,7 @@ impl Decode for IpAddr {
             0 => Ok(IpAddr::V4(Ipv4Addr::decode(decoder)?)),
             1 => Ok(IpAddr::V6(Ipv6Addr::decode(decoder)?)),
             found => Err(DecodeError::UnexpectedVariant {
-                allowed: crate::error::AllowedEnumVariants::Range { min: 0, max: 1 },
+                allowed: &crate::error::AllowedEnumVariants::Range { min: 0, max: 1 },
                 found,
                 type_name: core::any::type_name::<IpAddr>(),
             }),
@@ -345,7 +345,7 @@ impl Decode for SocketAddr {
             0 => Ok(SocketAddr::V4(SocketAddrV4::decode(decoder)?)),
             1 => Ok(SocketAddr::V6(SocketAddrV6::decode(decoder)?)),
             found => Err(DecodeError::UnexpectedVariant {
-                allowed: crate::error::AllowedEnumVariants::Range { min: 0, max: 1 },
+                allowed: &crate::error::AllowedEnumVariants::Range { min: 0, max: 1 },
                 found,
                 type_name: core::any::type_name::<SocketAddr>(),
             }),
@@ -400,7 +400,6 @@ impl std::error::Error for DecodeError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Utf8 { inner } => Some(inner),
-            Self::CStringNulError { inner } => Some(inner),
             _ => None,
         }
     }

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -285,7 +285,7 @@ fn test_c_style_enum() {
     fn expected_err(idx: u32) -> Result<CStyleEnum, bincode::error::DecodeError> {
         Err(bincode::error::DecodeError::UnexpectedVariant {
             type_name: "CStyleEnum",
-            allowed: bincode::error::AllowedEnumVariants::Allowed(&[1, 2, 3, 5, 6]),
+            allowed: &bincode::error::AllowedEnumVariants::Allowed(&[1, 2, 3, 5, 6]),
             found: idx,
         })
     }

--- a/tests/error_size.rs
+++ b/tests/error_size.rs
@@ -2,17 +2,17 @@
 
 #[test]
 fn decode_error_size() {
-	assert_eq!(std::mem::size_of::<bincode::error::DecodeError>(), 32);
+    assert_eq!(std::mem::size_of::<bincode::error::DecodeError>(), 32);
 }
 
 #[test]
 fn encode_error_size() {
-	#[cfg(feature = "std")]
-	assert_eq!(std::mem::size_of::<bincode::error::EncodeError>(), 40);
+    #[cfg(feature = "std")]
+    assert_eq!(std::mem::size_of::<bincode::error::EncodeError>(), 40);
 
-	#[cfg(all(feature = "alloc", not(feature = "std")))]
-	assert_eq!(std::mem::size_of::<bincode::error::EncodeError>(), 32);
+    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    assert_eq!(std::mem::size_of::<bincode::error::EncodeError>(), 32);
 
-	#[cfg(not(any(feature = "std", feature = "alloc")))]
-	assert_eq!(std::mem::size_of::<bincode::error::EncodeError>(), 24);
+    #[cfg(not(any(feature = "std", feature = "alloc")))]
+    assert_eq!(std::mem::size_of::<bincode::error::EncodeError>(), 24);
 }

--- a/tests/error_size.rs
+++ b/tests/error_size.rs
@@ -7,7 +7,7 @@ fn decode_error_size() {
 
 #[test]
 fn encode_error_size() {
-	#[cfg(all(feature = "std"))]
+	#[cfg(feature = "std")]
 	assert_eq!(std::mem::size_of::<bincode::error::EncodeError>(), 40);
 
 	#[cfg(all(feature = "alloc", not(feature = "std")))]

--- a/tests/error_size.rs
+++ b/tests/error_size.rs
@@ -7,10 +7,7 @@ fn decode_error_size() {
 
 #[test]
 fn encode_error_size() {
-    #[cfg(feature = "std")]
-    assert_eq!(std::mem::size_of::<bincode::error::EncodeError>(), 40);
-
-    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    #[cfg(any(feature = "std", feature = "alloc"))]
     assert_eq!(std::mem::size_of::<bincode::error::EncodeError>(), 32);
 
     #[cfg(not(any(feature = "std", feature = "alloc")))]

--- a/tests/error_size.rs
+++ b/tests/error_size.rs
@@ -1,0 +1,18 @@
+#![cfg(target_pointer_width = "64")]
+
+#[test]
+fn decode_error_size() {
+	assert_eq!(std::mem::size_of::<bincode::error::DecodeError>(), 32);
+}
+
+#[test]
+fn encode_error_size() {
+	#[cfg(all(feature = "std"))]
+	assert_eq!(std::mem::size_of::<bincode::error::EncodeError>(), 40);
+
+	#[cfg(all(feature = "alloc", not(feature = "std")))]
+	assert_eq!(std::mem::size_of::<bincode::error::EncodeError>(), 32);
+
+	#[cfg(not(any(feature = "std", feature = "alloc")))]
+	assert_eq!(std::mem::size_of::<bincode::error::EncodeError>(), 24);
+}

--- a/tests/issues/issue_498.rs
+++ b/tests/issues/issue_498.rs
@@ -11,7 +11,7 @@ fn test_issue_498() {
         bincode::decode_from_slice(&bytes, bincode::config::legacy().with_limit::<1024>());
 
     match out.unwrap_err() {
-        bincode::error::DecodeError::CStringNulError { inner: _ } => {}
+        bincode::error::DecodeError::CStringNulError { position: _ } => {}
         err => panic!("Expected CStringNullErr, found {:?}", err),
     }
 }


### PR DESCRIPTION
This is done by two tricks:

1. Packing the ~entire description of an enum with it's type name and~ allowed variants behind a `&'static` ref.
2. Reducing `DecodeError::CStringNulError` to just the position of the null byte.

~Aside from the extra struct being added, this is a breaking change due to type names for many manual impls being reduced to just the identifier name (derived impls were already just the identifier here). This is unfortunately necessary as `std::any::type_name` is not `const`, and even if it were using it with an external generic type would make it unusable in const environment, meaning it's impossible to construct a static `AllowedEnum` struct with it.~ `CStringNulError` I think is exotic enough and rare enough that dropping information here makes sense, if not we could also `Box` the internal error (std already allocates there anyway).

~If these changes are unacceptable, it's still possible to reduce the size of `DecodeError` to 40 bytes by just putting the `AllowedEnumVariants` behind a `&'static` ref, as that enum alone is 3 words wide.~