### PR TITLE
Encode variant index instead of variant value

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -19,4 +19,4 @@ description = "Implementation of #[derive(Encode, Decode)] for bincode"
 proc-macro = true
 
 [dependencies]
-virtue = "0.0.9"
+virtue = "0.0.10"

--- a/derive/src/derive_enum.rs
+++ b/derive/src/derive_enum.rs
@@ -12,7 +12,6 @@ impl DeriveEnum {
     fn iter_fields(&self) -> EnumVariantIterator {
         EnumVariantIterator {
             idx: 0,
-            last_val: None,
             variants: &self.variants,
         }
     }
@@ -401,7 +400,6 @@ impl DeriveEnum {
 struct EnumVariantIterator<'a> {
     variants: &'a [EnumVariant],
     idx: usize,
-    last_val: Option<(Literal, u32)>,
 }
 
 impl<'a> Iterator for EnumVariantIterator<'a> {
@@ -412,20 +410,7 @@ impl<'a> Iterator for EnumVariantIterator<'a> {
         let variant = self.variants.get(self.idx)?;
         self.idx += 1;
 
-        let tokens = if let Fields::Integer(lit) = &variant.fields {
-            let tree = TokenTree::Literal(lit.clone());
-            self.last_val = Some((lit.clone(), 0));
-            vec![tree]
-        } else if let Some((lit, add)) = self.last_val.as_mut() {
-            *add += 1;
-            vec![
-                TokenTree::Literal(lit.clone()),
-                TokenTree::Punct(Punct::new('+', Spacing::Alone)),
-                TokenTree::Literal(Literal::u32_suffixed(*add)),
-            ]
-        } else {
-            vec![TokenTree::Literal(Literal::u32_suffixed(idx as u32))]
-        };
+        let tokens = vec![TokenTree::Literal(Literal::u32_suffixed(idx as u32))];
 
         Some((tokens, variant))
     }

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -255,7 +255,7 @@ fn test_decode_borrowed_enum_tuple_variant() {
 
 #[derive(bincode::Decode, bincode::Encode, PartialEq, Eq, Debug)]
 enum CStyleEnum {
-    A = 1,
+    A = -1,
     B = 2,
     C,
     D = 5,
@@ -272,11 +272,11 @@ fn test_c_style_enum() {
         slice[0]
     }
 
-    assert_eq!(ser(CStyleEnum::A), 1);
-    assert_eq!(ser(CStyleEnum::B), 2);
-    assert_eq!(ser(CStyleEnum::C), 3);
-    assert_eq!(ser(CStyleEnum::D), 5);
-    assert_eq!(ser(CStyleEnum::E), 6);
+    assert_eq!(ser(CStyleEnum::A), 0);
+    assert_eq!(ser(CStyleEnum::B), 1);
+    assert_eq!(ser(CStyleEnum::C), 2);
+    assert_eq!(ser(CStyleEnum::D), 3);
+    assert_eq!(ser(CStyleEnum::E), 4);
 
     fn assert_de_successfully(num: u8, expected: CStyleEnum) {
         match bincode::decode_from_slice::<CStyleEnum, _>(&[num], bincode::config::standard()) {
@@ -295,21 +295,19 @@ fn test_c_style_enum() {
             }
             Err(DecodeError::UnexpectedVariant {
                 type_name: "CStyleEnum",
-                allowed: &bincode::error::AllowedEnumVariants::Allowed(&[1, 2, 3, 5, 6]),
+                allowed: &bincode::error::AllowedEnumVariants::Allowed(&[0, 1, 2, 3, 4]),
                 found,
             }) if found == num as u32 => {}
             Err(e) => panic!("Expected DecodeError::UnexpectedVariant, got {e:?}"),
         }
     }
 
-    assert_de_fails(0);
-    assert_de_successfully(1, CStyleEnum::A);
-    assert_de_successfully(2, CStyleEnum::B);
-    assert_de_successfully(3, CStyleEnum::C);
-    assert_de_fails(4);
-    assert_de_successfully(5, CStyleEnum::D);
-    assert_de_successfully(6, CStyleEnum::E);
-    assert_de_fails(7);
+    assert_de_successfully(0, CStyleEnum::A);
+    assert_de_successfully(1, CStyleEnum::B);
+    assert_de_successfully(2, CStyleEnum::C);
+    assert_de_successfully(3, CStyleEnum::D);
+    assert_de_successfully(4, CStyleEnum::E);
+    assert_de_fails(5);
 }
 
 macro_rules! macro_newtype {

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -32,3 +32,6 @@ mod issue_547;
 
 #[path = "issues/issue_570.rs"]
 mod issue_570;
+
+#[path = "issues/issue_592.rs"]
+mod issue_592;

--- a/tests/issues/issue_592.rs
+++ b/tests/issues/issue_592.rs
@@ -1,0 +1,8 @@
+#![cfg(all(feature = "derive", feature = "std"))]
+
+use bincode::{Decode, Encode};
+
+#[derive(Encode, Decode)]
+pub enum TypeOfFile {
+    Unknown = -1,
+}


### PR DESCRIPTION
If this looks good, a new crates.io release of `virtue` is needed.

Closes #592