### PR TITLE
Add a feature to disable extra debug info (#595)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ default = ["std", "derive"]
 std = ["alloc", "serde?/std"]
 alloc = ["serde?/alloc"]
 derive = ["bincode_derive"]
+no-extra-debug = ["bincode_derive/no-extra-debug"]
 
 [dependencies]
 bincode_derive = { path = "derive", version = "2.0.0-rc.2", optional = true }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -15,6 +15,9 @@ keywords = ["binary", "encode", "decode", "serialize", "deserialize"]
 license = "MIT"
 description = "Implementation of #[derive(Encode, Decode)] for bincode"
 
+[features]
+no-extra-debug = []
+
 [lib]
 proc-macro = true
 

--- a/derive/src/derive_enum.rs
+++ b/derive/src/derive_enum.rs
@@ -175,7 +175,15 @@ impl DeriveEnum {
 
                 variant_inner.ident_str("type_name");
                 variant_inner.punct(':');
-                variant_inner.lit_str(enum_name);
+                // we add the enum name in the generated error
+                if cfg!(feature = "no-extra-debug") {
+                    // if the feature is "no-extra-debug" we set an empty string rather than leaking the enum name
+                    // this is also useful for optimization
+                    variant_inner.lit_str("");
+                } else {
+                    // by default, we add the enum name to the generated error
+                    variant_inner.lit_str(enum_name);
+                }
                 variant_inner.punct(',');
 
                 variant_inner.ident_str("allowed");


### PR DESCRIPTION
The issue is in bincode_derive crate, where we are adding extra debug info that are leaking enum names in the final binary (which imply less optimization with a bigger binary size, and internal structure leak). I think we should use a proper feature flag to disable this. This is linked to #595.

It seems there is only one leak in the code in [this](https://github.com/bincode-org/bincode/blob/trunk/derive/src/derive_enum.rs#L178https://github.com/bincode-org/bincode/blob/trunk/derive/src/derive_enum.rs#L178) part of the code. I agree this debug line can be important, but should be optional for release build if required. A feature flag could be used to address that situation, and maybe it is useful for other cases like in https://github.com/bincode-org/bincode/issues/594.

This allows
- More optimization (smallest final binary size)
- No internal code structure leak (no enum name leak).