### PR TITLE
Add DecodeError::Other

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -179,6 +179,9 @@ pub enum DecodeError {
     },
 
     /// An uncommon error occurred, see the inner text for more information
+    Other(&'static str),
+
+    /// An uncommon error occurred, see the inner text for more information
     #[cfg(feature = "alloc")]
     OtherString(alloc::string::String),
 


### PR DESCRIPTION
There is an ` EncodeError::Other(&'static str)` in
https://github.com/bincode-org/bincode/blob/ba4d19695c837dc13b492ffa8cee602d20abba0a/src/error.rs#L18-L19
but not in `DecodeError`.

I think adding `Other(&'static str)` to `DecodeError` makes errors more user-friendly.