### PR TITLE
Add EncodedSize trait to calculate encoded sizes

### DIFF
--- a/derive/src/attribute.rs
+++ b/derive/src/attribute.rs
@@ -7,6 +7,7 @@ pub struct ContainerAttributes {
     pub decode_bounds: Option<(String, Literal)>,
     pub borrow_decode_bounds: Option<(String, Literal)>,
     pub encode_bounds: Option<(String, Literal)>,
+    pub encoded_size_bounds: Option<(String, Literal)>,
 }
 
 impl Default for ContainerAttributes {
@@ -17,6 +18,7 @@ impl Default for ContainerAttributes {
             decode_bounds: None,
             encode_bounds: None,
             borrow_decode_bounds: None,
+            encoded_size_bounds: None,
         }
     }
 }
@@ -71,6 +73,15 @@ impl FromAttribute for ContainerAttributes {
                     let val_string = val.to_string();
                     if val_string.starts_with('"') && val_string.ends_with('"') {
                         result.borrow_decode_bounds =
+                            Some((val_string[1..val_string.len() - 1].to_string(), val));
+                    } else {
+                        return Err(Error::custom_at("Should be a literal str", val.span()));
+                    }
+                }
+                ParsedAttribute::Property(key, val) if key.to_string() == "encoded_size_bounds" => {
+                    let val_string = val.to_string();
+                    if val_string.starts_with('"') && val_string.ends_with('"') {
+                        result.encoded_size_bounds =
                             Some((val_string[1..val_string.len() - 1].to_string(), val));
                     } else {
                         return Err(Error::custom_at("Should be a literal str", val.span()));

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -60,7 +60,7 @@ Then replace the following functions: (`Configuration` is `bincode::config::lega
 |||
 |`bincode::serialize(T)`|`bincode::serde::encode_to_vec(T, Configuration)`<br />`bincode::serde::encode_into_slice(T, &mut [u8], Configuration)`|
 |`bincode::serialize_into(std::io::Write, T)`|`bincode::serde::encode_into_std_write(T, std::io::Write, Configuration)`|
-|`bincode::serialized_size(T)`|Currently not implemented|
+|`bincode::serialized_size(T)`|`bincode::serde::encoded_size(T, Configuration)`|
 
 ## Migrating to `bincode-derive`
 
@@ -98,7 +98,7 @@ Then replace the following functions: (`Configuration` is `bincode::config::lega
 |||
 |`bincode::serialize(T)`|`bincode::encode_to_vec(T, Configuration)`<br />`bincode::encode_into_slice(t: T, &mut [u8], Configuration)`|
 |`bincode::serialize_into(std::io::Write, T)`|`bincode::encode_into_std_write(T, std::io::Write, Configuration)`|
-|`bincode::serialized_size(T)`|Currently not implemented|
+|`bincode::serialized_size(T)`|`bincode::encoded_size(T, Configuration)`|
 
 
 ### Bincode derive and libraries

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -31,3 +31,9 @@ name = "compat"
 path = "fuzz_targets/compat.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "encoded_size"
+path = "fuzz_targets/encoded_size.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/encoded_size.rs
+++ b/fuzz/fuzz_targets/encoded_size.rs
@@ -1,0 +1,52 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+use std::ffi::CString;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+use std::num::{NonZeroI128, NonZeroI32, NonZeroU128, NonZeroU32};
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+#[derive(bincode::Decode, bincode::Encode, bincode::EncodedSize, PartialEq, Debug)]
+enum AllTypes {
+    BTreeMap(BTreeMap<u8, u8>),
+    HashMap(HashMap<u8, u8>),
+    HashSet(HashSet<u8>),
+    BTreeSet(BTreeSet<u8>),
+    VecDeque(VecDeque<AllTypes>),
+    Vec(Vec<AllTypes>),
+    String(String),
+    Box(Box<AllTypes>),
+    BoxSlice(Box<[AllTypes]>),
+    Rc(Rc<AllTypes>),
+    Arc(Arc<AllTypes>),
+    CString(CString),
+    SystemTime(SystemTime),
+    Duration(Duration),
+    PathBuf(PathBuf),
+    IpAddr(IpAddr),
+    Ipv4Addr(Ipv4Addr),
+    Ipv6Addr(Ipv6Addr),
+    SocketAddr(SocketAddr),
+    SocketAddrV4(SocketAddrV4),
+    SocketAddrV6(SocketAddrV6),
+    NonZeroU32(NonZeroU32),
+    NonZeroI32(NonZeroI32),
+    NonZeroU128(NonZeroU128),
+    NonZeroI128(NonZeroI128),
+    // Cow(Cow<'static, [u8]>), Blocked, see comment on decode
+}
+
+fuzz_target!(|data: &[u8]| {
+    let config = bincode::config::standard().with_limit::<1024>();
+    let result: Result<(AllTypes, _), _> = bincode::decode_from_slice(data, config);
+
+    if let Ok((value, _)) = result {
+        let encoded_size = bincode::encoded_size(&value, config).expect("encoded size");
+        let encoded = bincode::encode_to_vec(&value, config).expect("round trip");
+        assert_eq!(encoded_size, encoded.len());
+    }
+});

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -1,4 +1,4 @@
-use crate::{de::Decode, enc::Encode, impl_borrow_decode};
+use crate::{de::Decode, enc::Encode, impl_borrow_decode, size::EncodedSize};
 use core::sync::atomic::Ordering;
 
 #[cfg(target_has_atomic = "ptr")]
@@ -27,6 +27,13 @@ impl Encode for AtomicBool {
 }
 
 #[cfg(target_has_atomic = "8")]
+impl EncodedSize for AtomicBool {
+    fn encoded_size<C: crate::config::Config>(&self) -> Result<usize, crate::error::EncodeError> {
+        self.load(Ordering::SeqCst).encoded_size::<C>()
+    }
+}
+
+#[cfg(target_has_atomic = "8")]
 impl Decode for AtomicBool {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicBool::new(Decode::decode(decoder)?))
@@ -42,6 +49,13 @@ impl Encode for AtomicU8 {
         encoder: &mut E,
     ) -> Result<(), crate::error::EncodeError> {
         self.load(Ordering::SeqCst).encode(encoder)
+    }
+}
+
+#[cfg(target_has_atomic = "8")]
+impl EncodedSize for AtomicU8 {
+    fn encoded_size<C: crate::config::Config>(&self) -> Result<usize, crate::error::EncodeError> {
+        self.load(Ordering::SeqCst).encoded_size::<C>()
     }
 }
 
@@ -65,6 +79,13 @@ impl Encode for AtomicU16 {
 }
 
 #[cfg(target_has_atomic = "16")]
+impl EncodedSize for AtomicU16 {
+    fn encoded_size<C: crate::config::Config>(&self) -> Result<usize, crate::error::EncodeError> {
+        self.load(Ordering::SeqCst).encoded_size::<C>()
+    }
+}
+
+#[cfg(target_has_atomic = "16")]
 impl Decode for AtomicU16 {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicU16::new(Decode::decode(decoder)?))
@@ -80,6 +101,13 @@ impl Encode for AtomicU32 {
         encoder: &mut E,
     ) -> Result<(), crate::error::EncodeError> {
         self.load(Ordering::SeqCst).encode(encoder)
+    }
+}
+
+#[cfg(target_has_atomic = "32")]
+impl EncodedSize for AtomicU32 {
+    fn encoded_size<C: crate::config::Config>(&self) -> Result<usize, crate::error::EncodeError> {
+        self.load(Ordering::SeqCst).encoded_size::<C>()
     }
 }
 
@@ -103,6 +131,13 @@ impl Encode for AtomicU64 {
 }
 
 #[cfg(target_has_atomic = "64")]
+impl EncodedSize for AtomicU64 {
+    fn encoded_size<C: crate::config::Config>(&self) -> Result<usize, crate::error::EncodeError> {
+        self.load(Ordering::SeqCst).encoded_size::<C>()
+    }
+}
+
+#[cfg(target_has_atomic = "64")]
 impl Decode for AtomicU64 {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicU64::new(Decode::decode(decoder)?))
@@ -118,6 +153,13 @@ impl Encode for AtomicUsize {
         encoder: &mut E,
     ) -> Result<(), crate::error::EncodeError> {
         self.load(Ordering::SeqCst).encode(encoder)
+    }
+}
+
+#[cfg(target_has_atomic = "ptr")]
+impl EncodedSize for AtomicUsize {
+    fn encoded_size<C: crate::config::Config>(&self) -> Result<usize, crate::error::EncodeError> {
+        self.load(Ordering::SeqCst).encoded_size::<C>()
     }
 }
 
@@ -141,6 +183,13 @@ impl Encode for AtomicI8 {
 }
 
 #[cfg(target_has_atomic = "8")]
+impl EncodedSize for AtomicI8 {
+    fn encoded_size<C: crate::config::Config>(&self) -> Result<usize, crate::error::EncodeError> {
+        self.load(Ordering::SeqCst).encoded_size::<C>()
+    }
+}
+
+#[cfg(target_has_atomic = "8")]
 impl Decode for AtomicI8 {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicI8::new(Decode::decode(decoder)?))
@@ -156,6 +205,13 @@ impl Encode for AtomicI16 {
         encoder: &mut E,
     ) -> Result<(), crate::error::EncodeError> {
         self.load(Ordering::SeqCst).encode(encoder)
+    }
+}
+
+#[cfg(target_has_atomic = "16")]
+impl EncodedSize for AtomicI16 {
+    fn encoded_size<C: crate::config::Config>(&self) -> Result<usize, crate::error::EncodeError> {
+        self.load(Ordering::SeqCst).encoded_size::<C>()
     }
 }
 
@@ -179,6 +235,13 @@ impl Encode for AtomicI32 {
 }
 
 #[cfg(target_has_atomic = "32")]
+impl EncodedSize for AtomicI32 {
+    fn encoded_size<C: crate::config::Config>(&self) -> Result<usize, crate::error::EncodeError> {
+        self.load(Ordering::SeqCst).encoded_size::<C>()
+    }
+}
+
+#[cfg(target_has_atomic = "32")]
 impl Decode for AtomicI32 {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicI32::new(Decode::decode(decoder)?))
@@ -198,6 +261,13 @@ impl Encode for AtomicI64 {
 }
 
 #[cfg(target_has_atomic = "64")]
+impl EncodedSize for AtomicI64 {
+    fn encoded_size<C: crate::config::Config>(&self) -> Result<usize, crate::error::EncodeError> {
+        self.load(Ordering::SeqCst).encoded_size::<C>()
+    }
+}
+
+#[cfg(target_has_atomic = "64")]
 impl Decode for AtomicI64 {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicI64::new(Decode::decode(decoder)?))
@@ -213,6 +283,13 @@ impl Encode for AtomicIsize {
         encoder: &mut E,
     ) -> Result<(), crate::error::EncodeError> {
         self.load(Ordering::SeqCst).encode(encoder)
+    }
+}
+
+#[cfg(target_has_atomic = "ptr")]
+impl EncodedSize for AtomicIsize {
+    fn encoded_size<C: crate::config::Config>(&self) -> Result<usize, crate::error::EncodeError> {
+        self.load(Ordering::SeqCst).encoded_size::<C>()
     }
 }
 

--- a/src/features/derive.rs
+++ b/src/features/derive.rs
@@ -1,2 +1,2 @@
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
-pub use bincode_derive::{BorrowDecode, Decode, Encode};
+pub use bincode_derive::{BorrowDecode, Decode, Encode, EncodedSize};

--- a/src/features/serde/mod.rs
+++ b/src/features/serde/mod.rs
@@ -58,10 +58,12 @@
 mod de_borrowed;
 mod de_owned;
 mod ser;
+mod size;
 
 pub use self::de_borrowed::*;
 pub use self::de_owned::*;
 pub use self::ser::*;
+pub use self::size::*;
 
 /// A serde-specific error that occurred while decoding.
 #[derive(Debug)]
@@ -219,6 +221,18 @@ where
         let serializer = ser::SerdeEncoder { enc: encoder };
         self.0.serialize(serializer)?;
         Ok(())
+    }
+}
+
+impl<T> crate::EncodedSize for Compat<T>
+where
+    T: serde::Serialize,
+{
+    fn encoded_size<C: crate::config::Config>(&self) -> Result<usize, crate::error::EncodeError> {
+        let mut encoded_size = 0;
+        let serializer = size::SerdeEncodedSize::<'_, C>::new(&mut encoded_size);
+        self.0.serialize(serializer)?;
+        Ok(encoded_size)
     }
 }
 

--- a/src/features/serde/size.rs
+++ b/src/features/serde/size.rs
@@ -1,0 +1,425 @@
+use super::EncodeError as SerdeEncodeError;
+use crate::{config::Config, error::EncodeError, size::EncodedSize};
+use core::marker::PhantomData;
+use serde::ser::*;
+
+/// Calculate the encoded size for the given value.
+pub fn encoded_size<T, C>(t: T, _config: C) -> Result<usize, EncodeError>
+where
+    T: Serialize,
+    C: Config,
+{
+    if C::SKIP_FIXED_ARRAY_LENGTH {
+        return Err(SerdeEncodeError::SkipFixedArrayLengthNotSupported.into());
+    }
+    let mut encoded_size: usize = 0;
+    let serializer = SerdeEncodedSize::<'_, C>::new(&mut encoded_size);
+    t.serialize(serializer)?;
+    Ok(encoded_size)
+}
+
+pub(super) struct SerdeEncodedSize<'a, C: Config> {
+    encoded_size: &'a mut usize,
+    config: PhantomData<C>,
+}
+
+impl<'a, C> SerdeEncodedSize<'a, C>
+where
+    C: Config,
+{
+    pub(super) fn new(encoded_size: &'a mut usize) -> Self {
+        SerdeEncodedSize {
+            encoded_size,
+            config: PhantomData,
+        }
+    }
+}
+
+impl<'a, C> Serializer for SerdeEncodedSize<'a, C>
+where
+    C: Config,
+{
+    type Ok = ();
+
+    type Error = EncodeError;
+
+    type SerializeSeq = Self;
+    type SerializeTuple = Self;
+    type SerializeTupleStruct = Self;
+    type SerializeTupleVariant = Self;
+    type SerializeMap = Self;
+    type SerializeStruct = Self;
+    type SerializeStructVariant = Self;
+
+    fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+        *self.encoded_size += v.encoded_size::<C>()?;
+        Ok(())
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+        *self.encoded_size += v.encoded_size::<C>()?;
+        Ok(())
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        *self.encoded_size += v.encoded_size::<C>()?;
+        Ok(())
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        *self.encoded_size += v.encoded_size::<C>()?;
+        Ok(())
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        *self.encoded_size += v.encoded_size::<C>()?;
+        Ok(())
+    }
+
+    serde::serde_if_integer128! {
+        fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
+            *self.encoded_size += v.encoded_size::<C>()?; Ok(())
+        }
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        *self.encoded_size += v.encoded_size::<C>()?;
+        Ok(())
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        *self.encoded_size += v.encoded_size::<C>()?;
+        Ok(())
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        *self.encoded_size += v.encoded_size::<C>()?;
+        Ok(())
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        *self.encoded_size += v.encoded_size::<C>()?;
+        Ok(())
+    }
+
+    serde::serde_if_integer128! {
+        fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
+            *self.encoded_size += v.encoded_size::<C>()?; Ok(())
+        }
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+        *self.encoded_size += v.encoded_size::<C>()?;
+        Ok(())
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+        *self.encoded_size += v.encoded_size::<C>()?;
+        Ok(())
+    }
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        *self.encoded_size += v.encoded_size::<C>()?;
+        Ok(())
+    }
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        *self.encoded_size += v.encoded_size::<C>()?;
+        Ok(())
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        *self.encoded_size += v.encoded_size::<C>()?;
+        Ok(())
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        *self.encoded_size += 0u8.encoded_size::<C>()?;
+        Ok(())
+    }
+
+    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        *self.encoded_size += 1u8.encoded_size::<C>()?;
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        *self.encoded_size += variant_index.encoded_size::<C>()?;
+        Ok(())
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        *self.encoded_size += variant_index.encoded_size::<C>()?;
+        value.serialize(self)
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        let len = len.ok_or_else(|| SerdeEncodeError::SequenceMustHaveLength.into())?;
+        *self.encoded_size += len.encoded_size::<C>()?;
+        Ok(Compound {
+            encoded_size: self.encoded_size,
+            config: self.config,
+        })
+    }
+
+    fn serialize_tuple(self, _: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Ok(self)
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Ok(self)
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        *self.encoded_size += variant_index.encoded_size::<C>()?;
+        Ok(Compound {
+            encoded_size: self.encoded_size,
+            config: self.config,
+        })
+    }
+
+    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        let len = len.ok_or_else(|| SerdeEncodeError::SequenceMustHaveLength.into())?;
+        *self.encoded_size += len.encoded_size::<C>()?;
+        Ok(Compound {
+            encoded_size: self.encoded_size,
+            config: self.config,
+        })
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Ok(Compound {
+            encoded_size: self.encoded_size,
+            config: self.config,
+        })
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        *self.encoded_size += variant_index.encoded_size::<C>()?;
+        Ok(Compound {
+            encoded_size: self.encoded_size,
+            config: self.config,
+        })
+    }
+
+    #[cfg(not(feature = "alloc"))]
+    fn collect_str<T: ?Sized>(self, _: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: core::fmt::Display,
+    {
+        Err(SerdeEncodeError::CannotCollectStr.into())
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+}
+
+type Compound<'a, C> = SerdeEncodedSize<'a, C>;
+
+impl<'a, C: Config> SerializeSeq for Compound<'a, C> {
+    type Ok = ();
+    type Error = EncodeError;
+
+    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(SerdeEncodedSize {
+            encoded_size: self.encoded_size,
+            config: self.config,
+        })
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl<'a, C: Config> SerializeTuple for Compound<'a, C> {
+    type Ok = ();
+    type Error = EncodeError;
+
+    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(SerdeEncodedSize {
+            encoded_size: self.encoded_size,
+            config: self.config,
+        })
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl<'a, C: Config> SerializeTupleStruct for Compound<'a, C> {
+    type Ok = ();
+    type Error = EncodeError;
+
+    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(SerdeEncodedSize {
+            encoded_size: self.encoded_size,
+            config: self.config,
+        })
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl<'a, C: Config> SerializeTupleVariant for Compound<'a, C> {
+    type Ok = ();
+    type Error = EncodeError;
+
+    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(SerdeEncodedSize {
+            encoded_size: self.encoded_size,
+            config: self.config,
+        })
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl<'a, C: Config> SerializeMap for Compound<'a, C> {
+    type Ok = ();
+    type Error = EncodeError;
+
+    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        key.serialize(SerdeEncodedSize {
+            encoded_size: self.encoded_size,
+            config: self.config,
+        })
+    }
+
+    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(SerdeEncodedSize {
+            encoded_size: self.encoded_size,
+            config: self.config,
+        })
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl<'a, C: Config> SerializeStruct for Compound<'a, C> {
+    type Ok = ();
+    type Error = EncodeError;
+
+    fn serialize_field<T: ?Sized>(
+        &mut self,
+        _key: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(SerdeEncodedSize {
+            encoded_size: self.encoded_size,
+            config: self.config,
+        })
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl<'a, C: Config> SerializeStructVariant for Compound<'a, C> {
+    type Ok = ();
+    type Error = EncodeError;
+
+    fn serialize_field<T: ?Sized>(
+        &mut self,
+        _key: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(SerdeEncodedSize {
+            encoded_size: self.encoded_size,
+            config: self.config,
+        })
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,10 +94,12 @@ pub mod config;
 pub mod de;
 pub mod enc;
 pub mod error;
+pub mod size;
 
 pub use atomic::*;
 pub use de::{BorrowDecode, Decode};
 pub use enc::Encode;
+pub use size::EncodedSize;
 
 use config::Config;
 
@@ -175,6 +177,14 @@ pub fn decode_from_reader<D: de::Decode, R: Reader, C: Config>(
 ) -> Result<D, error::DecodeError> {
     let mut decoder = de::DecoderImpl::<_, C>::new(reader, config);
     D::decode(&mut decoder)
+}
+
+/// Determine the encoded size of a value.
+pub fn encoded_size<E: EncodedSize, C: Config>(
+    val: E,
+    _config: C,
+) -> Result<usize, error::EncodeError> {
+    val.encoded_size::<C>()
 }
 
 // TODO: Currently our doctests fail when trying to include the specs because the specs depend on `derive` and `alloc`.

--- a/src/size/impl_tuples.rs
+++ b/src/size/impl_tuples.rs
@@ -1,0 +1,389 @@
+use super::EncodedSize;
+use crate::config::Config;
+use crate::error::EncodeError;
+
+impl<A> EncodedSize for (A,)
+where
+    A: EncodedSize,
+{
+    fn encoded_size<_C: Config>(&self) -> Result<usize, EncodeError> {
+        self.0.encoded_size::<_C>()
+    }
+}
+
+impl<A, B> EncodedSize for (A, B)
+where
+    A: EncodedSize,
+    B: EncodedSize,
+{
+    fn encoded_size<_C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(self.0.encoded_size::<_C>()? + self.1.encoded_size::<_C>()?)
+    }
+}
+
+impl<A, B, C> EncodedSize for (A, B, C)
+where
+    A: EncodedSize,
+    B: EncodedSize,
+    C: EncodedSize,
+{
+    fn encoded_size<_C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(self.0.encoded_size::<_C>()?
+            + self.1.encoded_size::<_C>()?
+            + self.2.encoded_size::<_C>()?)
+    }
+}
+
+impl<A, B, C, D> EncodedSize for (A, B, C, D)
+where
+    A: EncodedSize,
+    B: EncodedSize,
+    C: EncodedSize,
+    D: EncodedSize,
+{
+    fn encoded_size<_C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(self.0.encoded_size::<_C>()?
+            + self.1.encoded_size::<_C>()?
+            + self.2.encoded_size::<_C>()?
+            + self.3.encoded_size::<_C>()?)
+    }
+}
+
+impl<A, B, C, D, E> EncodedSize for (A, B, C, D, E)
+where
+    A: EncodedSize,
+    B: EncodedSize,
+    C: EncodedSize,
+    D: EncodedSize,
+    E: EncodedSize,
+{
+    fn encoded_size<_C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(self.0.encoded_size::<_C>()?
+            + self.1.encoded_size::<_C>()?
+            + self.2.encoded_size::<_C>()?
+            + self.3.encoded_size::<_C>()?
+            + self.4.encoded_size::<_C>()?)
+    }
+}
+
+impl<A, B, C, D, E, F> EncodedSize for (A, B, C, D, E, F)
+where
+    A: EncodedSize,
+    B: EncodedSize,
+    C: EncodedSize,
+    D: EncodedSize,
+    E: EncodedSize,
+    F: EncodedSize,
+{
+    fn encoded_size<_C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(self.0.encoded_size::<_C>()?
+            + self.1.encoded_size::<_C>()?
+            + self.2.encoded_size::<_C>()?
+            + self.3.encoded_size::<_C>()?
+            + self.4.encoded_size::<_C>()?
+            + self.5.encoded_size::<_C>()?)
+    }
+}
+
+impl<A, B, C, D, E, F, G> EncodedSize for (A, B, C, D, E, F, G)
+where
+    A: EncodedSize,
+    B: EncodedSize,
+    C: EncodedSize,
+    D: EncodedSize,
+    E: EncodedSize,
+    F: EncodedSize,
+    G: EncodedSize,
+{
+    fn encoded_size<_C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(self.0.encoded_size::<_C>()?
+            + self.1.encoded_size::<_C>()?
+            + self.2.encoded_size::<_C>()?
+            + self.3.encoded_size::<_C>()?
+            + self.4.encoded_size::<_C>()?
+            + self.5.encoded_size::<_C>()?
+            + self.6.encoded_size::<_C>()?)
+    }
+}
+
+impl<A, B, C, D, E, F, G, H> EncodedSize for (A, B, C, D, E, F, G, H)
+where
+    A: EncodedSize,
+    B: EncodedSize,
+    C: EncodedSize,
+    D: EncodedSize,
+    E: EncodedSize,
+    F: EncodedSize,
+    G: EncodedSize,
+    H: EncodedSize,
+{
+    fn encoded_size<_C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(self.0.encoded_size::<_C>()?
+            + self.1.encoded_size::<_C>()?
+            + self.2.encoded_size::<_C>()?
+            + self.3.encoded_size::<_C>()?
+            + self.4.encoded_size::<_C>()?
+            + self.5.encoded_size::<_C>()?
+            + self.6.encoded_size::<_C>()?
+            + self.7.encoded_size::<_C>()?)
+    }
+}
+
+impl<A, B, C, D, E, F, G, H, I> EncodedSize for (A, B, C, D, E, F, G, H, I)
+where
+    A: EncodedSize,
+    B: EncodedSize,
+    C: EncodedSize,
+    D: EncodedSize,
+    E: EncodedSize,
+    F: EncodedSize,
+    G: EncodedSize,
+    H: EncodedSize,
+    I: EncodedSize,
+{
+    fn encoded_size<_C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(self.0.encoded_size::<_C>()?
+            + self.1.encoded_size::<_C>()?
+            + self.2.encoded_size::<_C>()?
+            + self.3.encoded_size::<_C>()?
+            + self.4.encoded_size::<_C>()?
+            + self.5.encoded_size::<_C>()?
+            + self.6.encoded_size::<_C>()?
+            + self.7.encoded_size::<_C>()?
+            + self.8.encoded_size::<_C>()?)
+    }
+}
+
+impl<A, B, C, D, E, F, G, H, I, J> EncodedSize for (A, B, C, D, E, F, G, H, I, J)
+where
+    A: EncodedSize,
+    B: EncodedSize,
+    C: EncodedSize,
+    D: EncodedSize,
+    E: EncodedSize,
+    F: EncodedSize,
+    G: EncodedSize,
+    H: EncodedSize,
+    I: EncodedSize,
+    J: EncodedSize,
+{
+    fn encoded_size<_C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(self.0.encoded_size::<_C>()?
+            + self.1.encoded_size::<_C>()?
+            + self.2.encoded_size::<_C>()?
+            + self.3.encoded_size::<_C>()?
+            + self.4.encoded_size::<_C>()?
+            + self.5.encoded_size::<_C>()?
+            + self.6.encoded_size::<_C>()?
+            + self.7.encoded_size::<_C>()?
+            + self.8.encoded_size::<_C>()?
+            + self.9.encoded_size::<_C>()?)
+    }
+}
+
+impl<A, B, C, D, E, F, G, H, I, J, K> EncodedSize for (A, B, C, D, E, F, G, H, I, J, K)
+where
+    A: EncodedSize,
+    B: EncodedSize,
+    C: EncodedSize,
+    D: EncodedSize,
+    E: EncodedSize,
+    F: EncodedSize,
+    G: EncodedSize,
+    H: EncodedSize,
+    I: EncodedSize,
+    J: EncodedSize,
+    K: EncodedSize,
+{
+    fn encoded_size<_C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(self.0.encoded_size::<_C>()?
+            + self.1.encoded_size::<_C>()?
+            + self.2.encoded_size::<_C>()?
+            + self.3.encoded_size::<_C>()?
+            + self.4.encoded_size::<_C>()?
+            + self.5.encoded_size::<_C>()?
+            + self.6.encoded_size::<_C>()?
+            + self.7.encoded_size::<_C>()?
+            + self.8.encoded_size::<_C>()?
+            + self.9.encoded_size::<_C>()?
+            + self.10.encoded_size::<_C>()?)
+    }
+}
+
+impl<A, B, C, D, E, F, G, H, I, J, K, L> EncodedSize for (A, B, C, D, E, F, G, H, I, J, K, L)
+where
+    A: EncodedSize,
+    B: EncodedSize,
+    C: EncodedSize,
+    D: EncodedSize,
+    E: EncodedSize,
+    F: EncodedSize,
+    G: EncodedSize,
+    H: EncodedSize,
+    I: EncodedSize,
+    J: EncodedSize,
+    K: EncodedSize,
+    L: EncodedSize,
+{
+    fn encoded_size<_C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(self.0.encoded_size::<_C>()?
+            + self.1.encoded_size::<_C>()?
+            + self.2.encoded_size::<_C>()?
+            + self.3.encoded_size::<_C>()?
+            + self.4.encoded_size::<_C>()?
+            + self.5.encoded_size::<_C>()?
+            + self.6.encoded_size::<_C>()?
+            + self.7.encoded_size::<_C>()?
+            + self.8.encoded_size::<_C>()?
+            + self.9.encoded_size::<_C>()?
+            + self.10.encoded_size::<_C>()?
+            + self.11.encoded_size::<_C>()?)
+    }
+}
+
+impl<A, B, C, D, E, F, G, H, I, J, K, L, M> EncodedSize for (A, B, C, D, E, F, G, H, I, J, K, L, M)
+where
+    A: EncodedSize,
+    B: EncodedSize,
+    C: EncodedSize,
+    D: EncodedSize,
+    E: EncodedSize,
+    F: EncodedSize,
+    G: EncodedSize,
+    H: EncodedSize,
+    I: EncodedSize,
+    J: EncodedSize,
+    K: EncodedSize,
+    L: EncodedSize,
+    M: EncodedSize,
+{
+    fn encoded_size<_C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(self.0.encoded_size::<_C>()?
+            + self.1.encoded_size::<_C>()?
+            + self.2.encoded_size::<_C>()?
+            + self.3.encoded_size::<_C>()?
+            + self.4.encoded_size::<_C>()?
+            + self.5.encoded_size::<_C>()?
+            + self.6.encoded_size::<_C>()?
+            + self.7.encoded_size::<_C>()?
+            + self.8.encoded_size::<_C>()?
+            + self.9.encoded_size::<_C>()?
+            + self.10.encoded_size::<_C>()?
+            + self.11.encoded_size::<_C>()?
+            + self.12.encoded_size::<_C>()?)
+    }
+}
+
+impl<A, B, C, D, E, F, G, H, I, J, K, L, M, N> EncodedSize
+    for (A, B, C, D, E, F, G, H, I, J, K, L, M, N)
+where
+    A: EncodedSize,
+    B: EncodedSize,
+    C: EncodedSize,
+    D: EncodedSize,
+    E: EncodedSize,
+    F: EncodedSize,
+    G: EncodedSize,
+    H: EncodedSize,
+    I: EncodedSize,
+    J: EncodedSize,
+    K: EncodedSize,
+    L: EncodedSize,
+    M: EncodedSize,
+    N: EncodedSize,
+{
+    fn encoded_size<_C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(self.0.encoded_size::<_C>()?
+            + self.1.encoded_size::<_C>()?
+            + self.2.encoded_size::<_C>()?
+            + self.3.encoded_size::<_C>()?
+            + self.4.encoded_size::<_C>()?
+            + self.5.encoded_size::<_C>()?
+            + self.6.encoded_size::<_C>()?
+            + self.7.encoded_size::<_C>()?
+            + self.8.encoded_size::<_C>()?
+            + self.9.encoded_size::<_C>()?
+            + self.10.encoded_size::<_C>()?
+            + self.11.encoded_size::<_C>()?
+            + self.12.encoded_size::<_C>()?
+            + self.13.encoded_size::<_C>()?)
+    }
+}
+
+impl<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> EncodedSize
+    for (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)
+where
+    A: EncodedSize,
+    B: EncodedSize,
+    C: EncodedSize,
+    D: EncodedSize,
+    E: EncodedSize,
+    F: EncodedSize,
+    G: EncodedSize,
+    H: EncodedSize,
+    I: EncodedSize,
+    J: EncodedSize,
+    K: EncodedSize,
+    L: EncodedSize,
+    M: EncodedSize,
+    N: EncodedSize,
+    O: EncodedSize,
+{
+    fn encoded_size<_C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(self.0.encoded_size::<_C>()?
+            + self.1.encoded_size::<_C>()?
+            + self.2.encoded_size::<_C>()?
+            + self.3.encoded_size::<_C>()?
+            + self.4.encoded_size::<_C>()?
+            + self.5.encoded_size::<_C>()?
+            + self.6.encoded_size::<_C>()?
+            + self.7.encoded_size::<_C>()?
+            + self.8.encoded_size::<_C>()?
+            + self.9.encoded_size::<_C>()?
+            + self.10.encoded_size::<_C>()?
+            + self.11.encoded_size::<_C>()?
+            + self.12.encoded_size::<_C>()?
+            + self.13.encoded_size::<_C>()?
+            + self.14.encoded_size::<_C>()?)
+    }
+}
+
+impl<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> EncodedSize
+    for (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)
+where
+    A: EncodedSize,
+    B: EncodedSize,
+    C: EncodedSize,
+    D: EncodedSize,
+    E: EncodedSize,
+    F: EncodedSize,
+    G: EncodedSize,
+    H: EncodedSize,
+    I: EncodedSize,
+    J: EncodedSize,
+    K: EncodedSize,
+    L: EncodedSize,
+    M: EncodedSize,
+    N: EncodedSize,
+    O: EncodedSize,
+    P: EncodedSize,
+{
+    fn encoded_size<_C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(self.0.encoded_size::<_C>()?
+            + self.1.encoded_size::<_C>()?
+            + self.2.encoded_size::<_C>()?
+            + self.3.encoded_size::<_C>()?
+            + self.4.encoded_size::<_C>()?
+            + self.5.encoded_size::<_C>()?
+            + self.6.encoded_size::<_C>()?
+            + self.7.encoded_size::<_C>()?
+            + self.8.encoded_size::<_C>()?
+            + self.9.encoded_size::<_C>()?
+            + self.10.encoded_size::<_C>()?
+            + self.11.encoded_size::<_C>()?
+            + self.12.encoded_size::<_C>()?
+            + self.13.encoded_size::<_C>()?
+            + self.14.encoded_size::<_C>()?
+            + self.15.encoded_size::<_C>()?)
+    }
+}

--- a/src/size/impls.rs
+++ b/src/size/impls.rs
@@ -1,0 +1,384 @@
+use super::EncodedSize;
+use crate::{
+    config::{Config, IntEncoding},
+    error::EncodeError,
+};
+use core::{
+    cell::{Cell, RefCell},
+    marker::PhantomData,
+    num::{
+        NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
+        NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
+    },
+    ops::{Bound, Range, RangeInclusive},
+    time::Duration,
+};
+
+impl EncodedSize for () {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(0)
+    }
+}
+
+impl<T> EncodedSize for PhantomData<T> {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(0)
+    }
+}
+
+impl EncodedSize for bool {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        u8::from(*self).encoded_size::<C>()
+    }
+}
+
+impl EncodedSize for u8 {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(1)
+    }
+}
+
+impl EncodedSize for NonZeroU8 {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        self.get().encoded_size::<C>()
+    }
+}
+
+impl EncodedSize for u16 {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        match C::INT_ENCODING {
+            IntEncoding::Variable => Ok(crate::varint::varint_size_u16(*self)),
+            IntEncoding::Fixed => Ok(std::mem::size_of::<Self>()),
+        }
+    }
+}
+
+impl EncodedSize for NonZeroU16 {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        self.get().encoded_size::<C>()
+    }
+}
+
+impl EncodedSize for u32 {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        match C::INT_ENCODING {
+            IntEncoding::Variable => Ok(crate::varint::varint_size_u32(*self)),
+            IntEncoding::Fixed => Ok(std::mem::size_of::<Self>()),
+        }
+    }
+}
+
+impl EncodedSize for NonZeroU32 {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        self.get().encoded_size::<C>()
+    }
+}
+
+impl EncodedSize for u64 {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        match C::INT_ENCODING {
+            IntEncoding::Variable => Ok(crate::varint::varint_size_u64(*self)),
+            IntEncoding::Fixed => Ok(std::mem::size_of::<Self>()),
+        }
+    }
+}
+
+impl EncodedSize for NonZeroU64 {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        self.get().encoded_size::<C>()
+    }
+}
+
+impl EncodedSize for u128 {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        match C::INT_ENCODING {
+            IntEncoding::Variable => Ok(crate::varint::varint_size_u128(*self)),
+            IntEncoding::Fixed => Ok(std::mem::size_of::<Self>()),
+        }
+    }
+}
+
+impl EncodedSize for NonZeroU128 {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        self.get().encoded_size::<C>()
+    }
+}
+
+impl EncodedSize for usize {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        match C::INT_ENCODING {
+            IntEncoding::Variable => Ok(crate::varint::varint_size_usize(*self)),
+            IntEncoding::Fixed => Ok(std::mem::size_of::<u64>()),
+        }
+    }
+}
+
+impl EncodedSize for NonZeroUsize {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        self.get().encoded_size::<C>()
+    }
+}
+
+impl EncodedSize for i8 {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(1)
+    }
+}
+
+impl EncodedSize for NonZeroI8 {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        self.get().encoded_size::<C>()
+    }
+}
+
+impl EncodedSize for i16 {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        match C::INT_ENCODING {
+            IntEncoding::Variable => Ok(crate::varint::varint_size_i16(*self)),
+            IntEncoding::Fixed => Ok(std::mem::size_of::<Self>()),
+        }
+    }
+}
+
+impl EncodedSize for NonZeroI16 {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        self.get().encoded_size::<C>()
+    }
+}
+
+impl EncodedSize for i32 {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        match C::INT_ENCODING {
+            IntEncoding::Variable => Ok(crate::varint::varint_size_i32(*self)),
+            IntEncoding::Fixed => Ok(std::mem::size_of::<Self>()),
+        }
+    }
+}
+
+impl EncodedSize for NonZeroI32 {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        self.get().encoded_size::<C>()
+    }
+}
+
+impl EncodedSize for i64 {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        match C::INT_ENCODING {
+            IntEncoding::Variable => Ok(crate::varint::varint_size_i64(*self)),
+            IntEncoding::Fixed => Ok(std::mem::size_of::<Self>()),
+        }
+    }
+}
+
+impl EncodedSize for NonZeroI64 {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        self.get().encoded_size::<C>()
+    }
+}
+
+impl EncodedSize for i128 {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        match C::INT_ENCODING {
+            IntEncoding::Variable => Ok(crate::varint::varint_size_i128(*self)),
+            IntEncoding::Fixed => Ok(std::mem::size_of::<Self>()),
+        }
+    }
+}
+
+impl EncodedSize for NonZeroI128 {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        self.get().encoded_size::<C>()
+    }
+}
+
+impl EncodedSize for isize {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        match C::INT_ENCODING {
+            IntEncoding::Variable => Ok(crate::varint::varint_size_isize(*self)),
+            IntEncoding::Fixed => Ok(std::mem::size_of::<Self>()),
+        }
+    }
+}
+
+impl EncodedSize for NonZeroIsize {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        self.get().encoded_size::<C>()
+    }
+}
+
+impl EncodedSize for f32 {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(std::mem::size_of::<Self>())
+    }
+}
+
+impl EncodedSize for f64 {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(std::mem::size_of::<Self>())
+    }
+}
+
+impl EncodedSize for char {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(encoded_size_utf8(*self))
+    }
+}
+
+// BlockedTODO: https://github.com/rust-lang/rust/issues/37653
+//
+// We'll want to implement encoding for both &[u8] and &[T: EncodedSizedSize],
+// but those implementations overlap because u8 also implements EncodedSize
+// impl EncodedSize for &'_ [u8] {
+//     fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+//         encoder.writer().write(*self)
+//     }
+// }
+
+impl<T> EncodedSize for [T]
+where
+    T: EncodedSize,
+{
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        let mut size = super::size_slice_len::<C>(self.len())?;
+        for item in self {
+            size += item.encoded_size::<C>()?;
+        }
+        Ok(size)
+    }
+}
+
+const MAX_ONE_B: u32 = 0x80;
+const MAX_TWO_B: u32 = 0x800;
+const MAX_THREE_B: u32 = 0x10000;
+
+fn encoded_size_utf8(c: char) -> usize {
+    let code = c as u32;
+
+    if code < MAX_ONE_B {
+        1
+    } else if code < MAX_TWO_B {
+        2
+    } else if code < MAX_THREE_B {
+        3
+    } else {
+        4
+    }
+}
+
+impl EncodedSize for str {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        self.as_bytes().encoded_size::<C>()
+    }
+}
+
+impl<T, const N: usize> EncodedSize for [T; N]
+where
+    T: EncodedSize,
+{
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        let mut size = 0;
+        if !C::SKIP_FIXED_ARRAY_LENGTH {
+            size += super::size_slice_len::<C>(N)?;
+        }
+        for item in self.iter() {
+            size += item.encoded_size::<C>()?;
+        }
+        Ok(size)
+    }
+}
+
+impl<T> EncodedSize for Option<T>
+where
+    T: EncodedSize,
+{
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        let mut size = 1;
+        if let Some(val) = self {
+            size += val.encoded_size::<C>()?;
+        }
+        Ok(size)
+    }
+}
+
+impl<T, U> EncodedSize for Result<T, U>
+where
+    T: EncodedSize,
+    U: EncodedSize,
+{
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        match self {
+            Ok(val) => Ok(0u32.encoded_size::<C>()? + val.encoded_size::<C>()?),
+            Err(err) => Ok(1u32.encoded_size::<C>()? + err.encoded_size::<C>()?),
+        }
+    }
+}
+
+impl<T> EncodedSize for Cell<T>
+where
+    T: EncodedSize + Copy,
+{
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        T::encoded_size::<C>(&self.get())
+    }
+}
+
+impl<T> EncodedSize for RefCell<T>
+where
+    T: EncodedSize + ?Sized,
+{
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        let borrow_guard = self
+            .try_borrow()
+            .map_err(|e| EncodeError::RefCellAlreadyBorrowed {
+                inner: e,
+                type_name: core::any::type_name::<RefCell<T>>(),
+            })?;
+        T::encoded_size::<C>(&borrow_guard)
+    }
+}
+
+impl EncodedSize for Duration {
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(self.as_secs().encoded_size::<C>()? + self.subsec_nanos().encoded_size::<C>()?)
+    }
+}
+
+impl<T> EncodedSize for Range<T>
+where
+    T: EncodedSize,
+{
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(self.start.encoded_size::<C>()? + self.end.encoded_size::<C>()?)
+    }
+}
+
+impl<T> EncodedSize for RangeInclusive<T>
+where
+    T: EncodedSize,
+{
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        Ok(self.start().encoded_size::<C>()? + self.end().encoded_size::<C>()?)
+    }
+}
+
+impl<T> EncodedSize for Bound<T>
+where
+    T: EncodedSize,
+{
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        match self {
+            Self::Unbounded => 0u32.encoded_size::<C>(),
+            Self::Included(val) => Ok(1u32.encoded_size::<C>()? + val.encoded_size::<C>()?),
+            Self::Excluded(val) => Ok(2u32.encoded_size::<C>()? + val.encoded_size::<C>()?),
+        }
+    }
+}
+
+impl<'a, T> EncodedSize for &'a T
+where
+    T: EncodedSize + ?Sized,
+{
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError> {
+        T::encoded_size::<C>(self)
+    }
+}

--- a/src/size/mod.rs
+++ b/src/size/mod.rs
@@ -1,0 +1,58 @@
+//! Size determination structs and traits.
+
+mod impl_tuples;
+mod impls;
+
+use crate::config::Config;
+use crate::error::EncodeError;
+
+/// Any source whose size when encoded can be determined.
+///
+/// This trait should be implemented for all types that you want to be able to determine the encoded size ahead of actual encoding.
+///
+/// # Implementing this trait manually
+///
+/// If you want to implement this trait for your type, the easiest way is to add a `#[derive(bincode::EncodedSize)]`, build and check your `target/generated/bincode/` folder. This should generate a `<Struct name>_EncodedSize.rs` file.
+///
+/// For this struct:
+///
+/// ```
+/// struct Entity {
+///     pub x: f32,
+///     pub y: f32,
+/// }
+/// ```
+/// It will look something like:
+///
+/// ```
+/// # struct Entity {
+/// #     pub x: f32,
+/// #     pub y: f32,
+/// # }
+/// impl bincode::EncodedSize for Entity {
+///     fn encoded_size<C: bincode::config::Config>(
+///         &self,
+///     ) -> core::result::Result<usize, bincode::error::EncodeError> {
+///         let mut __encoded_size = 0;
+///         __encoded_size += bincode::EncodedSize::encoded_size::<C>(&self.x)?;
+///         __encoded_size += bincode::EncodedSize::encoded_size::<C>(&self.y)?;
+///         Ok(__encoded_size)
+///     }
+/// }
+/// ```
+///
+/// From here you can add/remove fields, or add custom logic.
+///
+/// # Interior Mutability
+///
+/// Types with interior mutability may be mutated between calls to `encoded_size` and one of the `encode` methods.  If this happens, the encoded size may change.  You must ensure that your encoded values are either not mutated between calls to `encoded_size` and `encode`, or handle the case where the actual encoded size is large than the value that `encoded_size` returns.
+pub trait EncodedSize {
+    /// Determine the encoded size of a given type.
+    fn encoded_size<C: Config>(&self) -> Result<usize, EncodeError>;
+}
+
+/// Returns the size of the encoded length of any slice, container, etc.
+#[inline]
+pub(crate) fn size_slice_len<C: Config>(len: usize) -> Result<usize, EncodeError> {
+    (len as u64).encoded_size::<C>()
+}

--- a/src/varint/mod.rs
+++ b/src/varint/mod.rs
@@ -2,6 +2,8 @@ mod decode_signed;
 mod decode_unsigned;
 mod encode_signed;
 mod encode_unsigned;
+mod size_signed;
+mod size_unsigned;
 
 pub use self::{
     decode_signed::{
@@ -20,6 +22,12 @@ pub use self::{
         varint_encode_u128, varint_encode_u16, varint_encode_u32, varint_encode_u64,
         varint_encode_usize,
     },
+    size_signed::{
+        varint_size_i128, varint_size_i16, varint_size_i32, varint_size_i64, varint_size_isize,
+    },
+    size_unsigned::{
+        varint_size_u128, varint_size_u16, varint_size_u32, varint_size_u64, varint_size_usize,
+    },
 };
 
 pub(self) const SINGLE_BYTE_MAX: u8 = 250;
@@ -27,3 +35,5 @@ pub(self) const U16_BYTE: u8 = 251;
 pub(self) const U32_BYTE: u8 = 252;
 pub(self) const U64_BYTE: u8 = 253;
 pub(self) const U128_BYTE: u8 = 254;
+pub(self) const SIGNED_SINGLE_BYTE_MIN: i8 = -125;
+pub(self) const SIGNED_SINGLE_BYTE_MAX: i8 = 125;

--- a/src/varint/size_signed.rs
+++ b/src/varint/size_signed.rs
@@ -1,0 +1,228 @@
+use super::{SIGNED_SINGLE_BYTE_MAX, SIGNED_SINGLE_BYTE_MIN};
+
+// Convenicence macro to specify a range with a specific type.
+macro_rules! range {
+    ($min:path, $max:path as $t:ty) => {
+        (($min as $t) ..= ($max as $t))
+    };
+}
+
+pub fn varint_size_i16(val: i16) -> usize {
+    if range!(SIGNED_SINGLE_BYTE_MIN, SIGNED_SINGLE_BYTE_MAX as i16).contains(&val) {
+        1
+    } else {
+        1 + std::mem::size_of::<u16>()
+    }
+}
+
+pub fn varint_size_i32(val: i32) -> usize {
+    if range!(SIGNED_SINGLE_BYTE_MIN, SIGNED_SINGLE_BYTE_MAX as i32).contains(&val) {
+        1
+    } else if range!(i16::MIN, i16::MAX as i32).contains(&val) {
+        1 + std::mem::size_of::<u16>()
+    } else {
+        1 + std::mem::size_of::<u32>()
+    }
+}
+
+pub fn varint_size_i64(val: i64) -> usize {
+    if range!(SIGNED_SINGLE_BYTE_MIN, SIGNED_SINGLE_BYTE_MAX as i64).contains(&val) {
+        1
+    } else if range!(i16::MIN, i16::MAX as i64).contains(&val) {
+        1 + std::mem::size_of::<u16>()
+    } else if range!(i32::MIN, i32::MAX as i64).contains(&val) {
+        1 + std::mem::size_of::<u32>()
+    } else {
+        1 + std::mem::size_of::<u64>()
+    }
+}
+
+pub fn varint_size_i128(val: i128) -> usize {
+    if range!(SIGNED_SINGLE_BYTE_MIN, SIGNED_SINGLE_BYTE_MAX as i128).contains(&val) {
+        1
+    } else if range!(i16::MIN, i16::MAX as i128).contains(&val) {
+        1 + std::mem::size_of::<u16>()
+    } else if range!(i32::MIN, i32::MAX as i128).contains(&val) {
+        1 + std::mem::size_of::<u32>()
+    } else if range!(i64::MIN, i64::MAX as i128).contains(&val) {
+        1 + std::mem::size_of::<u64>()
+    } else {
+        1 + std::mem::size_of::<u128>()
+    }
+}
+
+pub fn varint_size_isize(val: isize) -> usize {
+    // isize is being encoded as a i64
+    varint_size_i64(val as i64)
+}
+
+#[test]
+fn test_size_i16() {
+    // these should all encode to a single byte
+    for i in range!(SIGNED_SINGLE_BYTE_MIN, SIGNED_SINGLE_BYTE_MAX as i16) {
+        assert_eq!(varint_size_i16(i), 1, "value: {}", i);
+    }
+
+    // these values should encode in 3 bytes (leading byte + 2 bytes)
+    // Values chosen at random, add new cases as needed
+    for i in [
+        i16::MIN,
+        -1000,
+        -200,
+        SIGNED_SINGLE_BYTE_MIN as i16 - 1,
+        SIGNED_SINGLE_BYTE_MAX as i16 + 1,
+        222,
+        1234,
+        i16::MAX,
+    ] {
+        assert_eq!(varint_size_i16(i), 3, "value: {}", i);
+    }
+}
+
+#[test]
+fn test_size_i32() {
+    // these should all encode to a single byte
+    for i in range!(SIGNED_SINGLE_BYTE_MIN, SIGNED_SINGLE_BYTE_MAX as i32) {
+        assert_eq!(varint_size_i32(i), 1, "value: {}", i);
+    }
+
+    // these values should encode in 3 bytes (leading byte + 2 bytes)
+    // Values chosen at random, add new cases as needed
+    for i in [
+        i16::MIN as i32,
+        -1000,
+        -200,
+        SIGNED_SINGLE_BYTE_MIN as i32 - 1,
+        SIGNED_SINGLE_BYTE_MAX as i32 + 1,
+        222,
+        1234,
+        i16::MAX as i32,
+    ] {
+        assert_eq!(varint_size_i32(i), 3, "value: {}", i);
+    }
+
+    // these values should encode in 5 bytes (leading byte + 4 bytes)
+    // Values chosen at random, add new cases as needed
+    for i in [
+        i32::MIN,
+        -1_000_000,
+        i16::MIN as i32 - 1,
+        i16::MAX as i32 + 1,
+        100_000,
+        1_000_000,
+        i32::MAX,
+    ] {
+        assert_eq!(varint_size_i32(i), 5, "value: {}", i);
+    }
+}
+
+#[test]
+fn test_size_i64() {
+    // these should all encode to a single byte
+    for i in range!(SIGNED_SINGLE_BYTE_MIN, SIGNED_SINGLE_BYTE_MAX as i64) {
+        assert_eq!(varint_size_i64(i), 1, "value: {}", i);
+    }
+
+    // these values should encode in 3 bytes (leading byte + 2 bytes)
+    // Values chosen at random, add new cases as needed
+    for i in [
+        i16::MIN as i64,
+        -1000,
+        -200,
+        SIGNED_SINGLE_BYTE_MIN as i64 - 1,
+        SIGNED_SINGLE_BYTE_MAX as i64 + 1,
+        222,
+        1234,
+        i16::MAX as i64,
+    ] {
+        assert_eq!(varint_size_i64(i), 3, "value: {}", i);
+    }
+
+    // these values should encode in 5 bytes (leading byte + 4 bytes)
+    // Values chosen at random, add new cases as needed
+    for i in [
+        i32::MIN as i64,
+        -1_000_000,
+        i16::MIN as i64 - 1,
+        i16::MAX as i64 + 1,
+        100_000,
+        1_000_000,
+        i32::MAX as i64,
+    ] {
+        assert_eq!(varint_size_i64(i), 5, "value: {}", i);
+    }
+
+    // these values should encode in 9 bytes (leading byte + 8 bytes)
+    // Values chosen at random, add new cases as needed
+    for i in [
+        i64::MIN,
+        -6_000_000_000,
+        i32::MIN as i64 - 1,
+        i32::MAX as i64 + 1,
+        5_000_000_000,
+        i64::MAX,
+    ] {
+        assert_eq!(varint_size_i64(i), 9, "value: {}", i);
+    }
+}
+
+#[test]
+fn test_size_i128() {
+    // these should all encode to a single byte
+    for i in range!(SIGNED_SINGLE_BYTE_MIN, SIGNED_SINGLE_BYTE_MAX as i128) {
+        assert_eq!(varint_size_i128(i), 1, "value: {}", i);
+    }
+
+    // these values should encode in 3 bytes (leading byte + 2 bytes)
+    // Values chosen at random, add new cases as needed
+    for i in [
+        i16::MIN as i128,
+        -1000,
+        -200,
+        SIGNED_SINGLE_BYTE_MIN as i128 - 1,
+        SIGNED_SINGLE_BYTE_MAX as i128 + 1,
+        222,
+        1234,
+        i16::MAX as i128,
+    ] {
+        assert_eq!(varint_size_i128(i), 3, "value: {}", i);
+    }
+
+    // these values should encode in 5 bytes (leading byte + 4 bytes)
+    // Values chosen at random, add new cases as needed
+    for i in [
+        i32::MIN as i128,
+        -1_000_000,
+        i16::MIN as i128 - 1,
+        i16::MAX as i128 + 1,
+        100_000,
+        1_000_000,
+        i32::MAX as i128,
+    ] {
+        assert_eq!(varint_size_i128(i), 5, "value: {}", i);
+    }
+
+    // these values should encode in 9 bytes (leading byte + 8 bytes)
+    // Values chosen at random, add new cases as needed
+    for i in [
+        i64::MIN as i128,
+        -6_000_000_000,
+        i32::MIN as i128 - 1,
+        i32::MAX as i128 + 1,
+        5_000_000_000,
+        i64::MAX as i128,
+    ] {
+        assert_eq!(varint_size_i128(i), 9, "value: {}", i);
+    }
+
+    // these values should encode in 17 bytes (leading byte + 16 bytes)
+    // Values chosen at random, add new cases as needed
+    for i in [
+        i128::MIN,
+        i64::MIN as i128 - 1,
+        i64::MAX as i128 + 1,
+        i128::MAX,
+    ] {
+        assert_eq!(varint_size_i128(i), 17, "value: {}", i);
+    }
+}

--- a/src/varint/size_unsigned.rs
+++ b/src/varint/size_unsigned.rs
@@ -1,0 +1,174 @@
+use super::SINGLE_BYTE_MAX;
+
+pub fn varint_size_u16(val: u16) -> usize {
+    if val <= SINGLE_BYTE_MAX as _ {
+        1
+    } else {
+        1 + std::mem::size_of::<u16>()
+    }
+}
+
+pub fn varint_size_u32(val: u32) -> usize {
+    if val <= SINGLE_BYTE_MAX as _ {
+        1
+    } else if val <= u16::MAX as _ {
+        1 + std::mem::size_of::<u16>()
+    } else {
+        1 + std::mem::size_of::<u32>()
+    }
+}
+
+pub fn varint_size_u64(val: u64) -> usize {
+    if val <= SINGLE_BYTE_MAX as _ {
+        1
+    } else if val <= u16::MAX as _ {
+        1 + std::mem::size_of::<u16>()
+    } else if val <= u32::MAX as _ {
+        1 + std::mem::size_of::<u32>()
+    } else {
+        1 + std::mem::size_of::<u64>()
+    }
+}
+
+pub fn varint_size_u128(val: u128) -> usize {
+    if val <= SINGLE_BYTE_MAX as _ {
+        1
+    } else if val <= u16::MAX as _ {
+        1 + std::mem::size_of::<u16>()
+    } else if val <= u32::MAX as _ {
+        1 + std::mem::size_of::<u32>()
+    } else if val <= u64::MAX as _ {
+        1 + std::mem::size_of::<u64>()
+    } else {
+        1 + std::mem::size_of::<u128>()
+    }
+}
+
+pub fn varint_size_usize(val: usize) -> usize {
+    // usize is being encoded as a u64
+    varint_size_u64(val as u64)
+}
+
+#[test]
+fn test_size_u16() {
+    // these should all encode to a single byte
+    for i in 0u16..=SINGLE_BYTE_MAX as u16 {
+        assert_eq!(varint_size_u16(i), 1, "value: {}", i);
+    }
+
+    // these values should encode in 3 bytes (leading byte + 2 bytes)
+    // Values chosen at random, add new cases as needed
+    for i in [
+        SINGLE_BYTE_MAX as u16 + 1,
+        300,
+        500,
+        700,
+        888,
+        1234,
+        u16::MAX,
+    ] {
+        assert_eq!(varint_size_u16(i), 3, "value: {}", i);
+    }
+}
+
+#[test]
+fn test_size_u32() {
+    // these should all encode to a single byte
+    for i in 0u32..=SINGLE_BYTE_MAX as u32 {
+        assert_eq!(varint_size_u32(i), 1, "value: {}", i);
+    }
+
+    // these values should encode in 3 bytes (leading byte + 2 bytes)
+    // Values chosen at random, add new cases as needed
+    for i in [
+        SINGLE_BYTE_MAX as u32 + 1,
+        300,
+        500,
+        700,
+        888,
+        1234,
+        u16::MAX as u32,
+    ] {
+        assert_eq!(varint_size_u32(i), 3, "value: {}", i);
+    }
+
+    // these values should encode in 5 bytes (leading byte + 4 bytes)
+    // Values chosen at random, add new cases as needed
+    for i in [u16::MAX as u32 + 1, 100_000, 1_000_000, u32::MAX] {
+        assert_eq!(varint_size_u32(i), 5, "value: {}", i);
+    }
+}
+
+#[test]
+fn test_size_u64() {
+    // these should all encode to a single byte
+    for i in 0u64..=SINGLE_BYTE_MAX as u64 {
+        assert_eq!(varint_size_u64(i), 1, "value: {}", i);
+    }
+
+    // these values should encode in 3 bytes (leading byte + 2 bytes)
+    // Values chosen at random, add new cases as needed
+    for i in [
+        SINGLE_BYTE_MAX as u64 + 1,
+        300,
+        500,
+        700,
+        888,
+        1234,
+        u16::MAX as u64,
+    ] {
+        assert_eq!(varint_size_u64(i), 3, "value: {}", i);
+    }
+
+    // these values should encode in 5 bytes (leading byte + 4 bytes)
+    // Values chosen at random, add new cases as needed
+    for i in [u16::MAX as u64 + 1, 100_000, 1_000_000, u32::MAX as u64] {
+        assert_eq!(varint_size_u64(i), 5, "value: {}", i);
+    }
+
+    // these values should encode in 9 bytes (leading byte + 8 bytes)
+    // Values chosen at random, add new cases as needed
+    for i in [u32::MAX as u64 + 1, 5_000_000_000, u64::MAX] {
+        assert_eq!(varint_size_u64(i), 9, "value: {}", i);
+    }
+}
+
+#[test]
+fn test_size_u128() {
+    // these should all encode to a single byte
+    for i in 0u128..=SINGLE_BYTE_MAX as u128 {
+        assert_eq!(varint_size_u128(i), 1, "value: {}", i);
+    }
+
+    // these values should encode in 3 bytes (leading byte + 2 bytes)
+    // Values chosen at random, add new cases as needed
+    for i in [
+        SINGLE_BYTE_MAX as u128 + 1,
+        300,
+        500,
+        700,
+        888,
+        1234,
+        u16::MAX as u128,
+    ] {
+        assert_eq!(varint_size_u128(i), 3, "value: {}", i);
+    }
+
+    // these values should encode in 5 bytes (leading byte + 4 bytes)
+    // Values chosen at random, add new cases as needed
+    for i in [u16::MAX as u128 + 1, 100_000, 1_000_000, u32::MAX as u128] {
+        assert_eq!(varint_size_u128(i), 5, "value: {}", i);
+    }
+
+    // these values should encode in 9 bytes (leading byte + 8 bytes)
+    // Values chosen at random, add new cases as needed
+    for i in [u32::MAX as u128 + 1, 5_000_000_000, u64::MAX as u128] {
+        assert_eq!(varint_size_u128(i), 9, "value: {}", i);
+    }
+
+    // these values should encode in 17 bytes (leading byte + 16 bytes)
+    // Values chosen at random, add new cases as needed
+    for i in [u64::MAX as u128 + 1, u128::MAX] {
+        assert_eq!(varint_size_u128(i), 17, "value: {}", i);
+    }
+}

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -2,7 +2,7 @@
 
 use bincode::error::DecodeError;
 
-#[derive(bincode::Encode, PartialEq, Debug)]
+#[derive(bincode::Encode, bincode::EncodedSize, PartialEq, Debug)]
 pub(crate) struct Test<T> {
     a: T,
     b: u32,
@@ -17,9 +17,11 @@ fn test_encode() {
         c: 20u8,
     };
     let mut slice = [0u8; 1024];
+    let encoded_size = bincode::encoded_size(&start, bincode::config::standard()).unwrap();
     let bytes_written =
         bincode::encode_into_slice(start, &mut slice, bincode::config::standard()).unwrap();
     assert_eq!(bytes_written, 3);
+    assert_eq!(bytes_written, encoded_size);
     assert_eq!(&slice[..bytes_written], &[10, 10, 20]);
 }
 #[derive(PartialEq, Debug, Eq)]
@@ -71,7 +73,7 @@ fn test_decode() {
     assert_eq!(len, 5);
 }
 
-#[derive(bincode::BorrowDecode, bincode::Encode, PartialEq, Debug, Eq)]
+#[derive(bincode::BorrowDecode, bincode::Encode, bincode::EncodedSize, PartialEq, Debug, Eq)]
 pub struct Test3<'a> {
     a: &'a str,
     b: u32,
@@ -89,24 +91,28 @@ fn test_encode_decode_str() {
     };
     let mut slice = [0u8; 100];
 
+    let encoded_size = bincode::encoded_size(&start, bincode::config::standard()).unwrap();
     let len = bincode::encode_into_slice(&start, &mut slice, bincode::config::standard()).unwrap();
     assert_eq!(len, 21);
+    assert_eq!(len, encoded_size);
     let (end, len): (Test3, usize) =
         bincode::borrow_decode_from_slice(&slice[..len], bincode::config::standard()).unwrap();
     assert_eq!(end, start);
     assert_eq!(len, 21);
 }
 
-#[derive(bincode::Encode, bincode::Decode, PartialEq, Debug, Eq)]
+#[derive(bincode::Encode, bincode::Decode, bincode::EncodedSize, PartialEq, Debug, Eq)]
 pub struct TestTupleStruct(u32, u32, u32);
 
 #[test]
 fn test_encode_tuple() {
     let start = TestTupleStruct(5, 10, 1024);
     let mut slice = [0u8; 1024];
+    let encoded_size = bincode::encoded_size(&start, bincode::config::standard()).unwrap();
     let bytes_written =
         bincode::encode_into_slice(start, &mut slice, bincode::config::standard()).unwrap();
     assert_eq!(bytes_written, 5);
+    assert_eq!(bytes_written, encoded_size);
     assert_eq!(&slice[..bytes_written], &[5, 10, 251, 0, 4]);
 }
 
@@ -120,7 +126,7 @@ fn test_decode_tuple() {
     assert_eq!(len, 5);
 }
 
-#[derive(bincode::Encode, bincode::Decode, PartialEq, Debug, Eq)]
+#[derive(bincode::Encode, bincode::Decode, bincode::EncodedSize, PartialEq, Debug, Eq)]
 pub enum TestEnum {
     Foo,
     Bar { name: u32 },
@@ -130,9 +136,11 @@ pub enum TestEnum {
 fn test_encode_enum_struct_variant() {
     let start = TestEnum::Bar { name: 5u32 };
     let mut slice = [0u8; 1024];
+    let encoded_size = bincode::encoded_size(&start, bincode::config::standard()).unwrap();
     let bytes_written =
         bincode::encode_into_slice(start, &mut slice, bincode::config::standard()).unwrap();
     assert_eq!(bytes_written, 2);
+    assert_eq!(bytes_written, encoded_size);
     assert_eq!(&slice[..bytes_written], &[1, 5]);
 }
 
@@ -160,9 +168,11 @@ fn test_decode_enum_unit_variant() {
 fn test_encode_enum_unit_variant() {
     let start = TestEnum::Foo;
     let mut slice = [0u8; 1024];
+    let encoded_size = bincode::encoded_size(&start, bincode::config::standard()).unwrap();
     let bytes_written =
         bincode::encode_into_slice(start, &mut slice, bincode::config::standard()).unwrap();
     assert_eq!(bytes_written, 1);
+    assert_eq!(bytes_written, encoded_size);
     assert_eq!(&slice[..bytes_written], &[0]);
 }
 
@@ -170,9 +180,11 @@ fn test_encode_enum_unit_variant() {
 fn test_encode_enum_tuple_variant() {
     let start = TestEnum::Baz(5, 10, 1024);
     let mut slice = [0u8; 1024];
+    let encoded_size = bincode::encoded_size(&start, bincode::config::standard()).unwrap();
     let bytes_written =
         bincode::encode_into_slice(start, &mut slice, bincode::config::standard()).unwrap();
     assert_eq!(bytes_written, 6);
+    assert_eq!(bytes_written, encoded_size);
     assert_eq!(&slice[..bytes_written], &[2, 5, 10, 251, 0, 4]);
 }
 
@@ -186,7 +198,7 @@ fn test_decode_enum_tuple_variant() {
     assert_eq!(len, 6);
 }
 
-#[derive(bincode::Encode, bincode::BorrowDecode, PartialEq, Debug, Eq)]
+#[derive(bincode::Encode, bincode::EncodedSize, bincode::BorrowDecode, PartialEq, Debug, Eq)]
 pub enum TestEnum2<'a> {
     Foo,
     Bar { name: &'a str },
@@ -197,9 +209,11 @@ pub enum TestEnum2<'a> {
 fn test_encode_borrowed_enum_struct_variant() {
     let start = TestEnum2::Bar { name: "foo" };
     let mut slice = [0u8; 1024];
+    let encoded_size = bincode::encoded_size(&start, bincode::config::standard()).unwrap();
     let bytes_written =
         bincode::encode_into_slice(start, &mut slice, bincode::config::standard()).unwrap();
     assert_eq!(bytes_written, 5);
+    assert_eq!(bytes_written, encoded_size);
     assert_eq!(&slice[..bytes_written], &[1, 3, 102, 111, 111]);
 }
 
@@ -227,9 +241,11 @@ fn test_decode_borrowed_enum_unit_variant() {
 fn test_encode_borrowed_enum_unit_variant() {
     let start = TestEnum2::Foo;
     let mut slice = [0u8; 1024];
+    let encoded_size = bincode::encoded_size(&start, bincode::config::standard()).unwrap();
     let bytes_written =
         bincode::encode_into_slice(start, &mut slice, bincode::config::standard()).unwrap();
     assert_eq!(bytes_written, 1);
+    assert_eq!(bytes_written, encoded_size);
     assert_eq!(&slice[..bytes_written], &[0]);
 }
 
@@ -237,9 +253,11 @@ fn test_encode_borrowed_enum_unit_variant() {
 fn test_encode_borrowed_enum_tuple_variant() {
     let start = TestEnum2::Baz(5, 10, 1024);
     let mut slice = [0u8; 1024];
+    let encoded_size = bincode::encoded_size(&start, bincode::config::standard()).unwrap();
     let bytes_written =
         bincode::encode_into_slice(start, &mut slice, bincode::config::standard()).unwrap();
     assert_eq!(bytes_written, 6);
+    assert_eq!(bytes_written, encoded_size);
     assert_eq!(&slice[..bytes_written], &[2, 5, 10, 251, 0, 4]);
 }
 
@@ -253,7 +271,7 @@ fn test_decode_borrowed_enum_tuple_variant() {
     assert_eq!(len, 6);
 }
 
-#[derive(bincode::Decode, bincode::Encode, PartialEq, Eq, Debug)]
+#[derive(bincode::Decode, bincode::Encode, bincode::EncodedSize, PartialEq, Eq, Debug)]
 enum CStyleEnum {
     A = -1,
     B = 2,
@@ -266,9 +284,11 @@ enum CStyleEnum {
 fn test_c_style_enum() {
     fn ser(e: CStyleEnum) -> u8 {
         let mut slice = [0u8; 10];
+        let encoded_size = bincode::encoded_size(&e, bincode::config::standard()).unwrap();
         let bytes_written =
             bincode::encode_into_slice(e, &mut slice, bincode::config::standard()).unwrap();
         assert_eq!(bytes_written, 1);
+        assert_eq!(bytes_written, encoded_size);
         slice[0]
     }
 
@@ -312,7 +332,7 @@ fn test_c_style_enum() {
 
 macro_rules! macro_newtype {
     ($name:ident) => {
-        #[derive(bincode::Encode, bincode::Decode, PartialEq, Eq, Debug)]
+        #[derive(bincode::Encode, bincode::Decode, bincode::EncodedSize, PartialEq, Eq, Debug)]
         pub struct $name(pub usize);
     };
 }
@@ -322,10 +342,13 @@ macro_newtype!(MacroNewType);
 fn test_macro_newtype() {
     for val in [0, 100, usize::MAX] {
         let mut usize_slice = [0u8; 10];
+        let usize_encoded_size = bincode::encoded_size(&val, bincode::config::standard()).unwrap();
         let usize_len =
             bincode::encode_into_slice(val, &mut usize_slice, bincode::config::standard()).unwrap();
 
         let mut newtype_slice = [0u8; 10];
+        let newtype_encoded_size =
+            bincode::encoded_size(&val, bincode::config::standard()).unwrap();
         let newtype_len = bincode::encode_into_slice(
             MacroNewType(val),
             &mut newtype_slice,
@@ -335,6 +358,8 @@ fn test_macro_newtype() {
 
         assert_eq!(usize_len, newtype_len);
         assert_eq!(usize_slice, newtype_slice);
+        assert_eq!(usize_len, usize_encoded_size);
+        assert_eq!(newtype_len, newtype_encoded_size);
 
         let (newtype, len) = bincode::decode_from_slice::<MacroNewType, _>(
             &newtype_slice,
@@ -346,7 +371,7 @@ fn test_macro_newtype() {
     }
 }
 
-#[derive(bincode::Encode, bincode::Decode, Debug)]
+#[derive(bincode::Encode, bincode::Decode, bincode::EncodedSize, Debug)]
 pub enum EmptyEnum {}
 
 #[derive(bincode::Encode, bincode::BorrowDecode, Debug)]
@@ -363,7 +388,7 @@ fn test_empty_enum_decode() {
     }
 }
 
-#[derive(bincode::Encode, bincode::Decode, PartialEq, Debug, Eq)]
+#[derive(bincode::Encode, bincode::Decode, bincode::EncodedSize, PartialEq, Debug, Eq)]
 pub enum TestWithGeneric<T> {
     Foo,
     Bar(T),
@@ -373,6 +398,7 @@ pub enum TestWithGeneric<T> {
 fn test_enum_with_generics_roundtrip() {
     let start = TestWithGeneric::Bar(1234);
     let mut slice = [0u8; 10];
+    let encoded_size = bincode::encoded_size(&start, bincode::config::standard()).unwrap();
     let bytes_written =
         bincode::encode_into_slice(&start, &mut slice, bincode::config::standard()).unwrap();
     assert_eq!(
@@ -383,6 +409,7 @@ fn test_enum_with_generics_roundtrip() {
             210, 4 // 1234
         ]
     );
+    assert_eq!(bytes_written, encoded_size);
 
     let decoded: TestWithGeneric<u32> =
         bincode::decode_from_slice(&slice[..bytes_written], bincode::config::standard())
@@ -392,9 +419,11 @@ fn test_enum_with_generics_roundtrip() {
 
     let start = TestWithGeneric::<()>::Foo;
     let mut slice = [0u8; 10];
+    let encoded_size = bincode::encoded_size(&start, bincode::config::standard()).unwrap();
     let bytes_written =
         bincode::encode_into_slice(&start, &mut slice, bincode::config::standard()).unwrap();
     assert_eq!(&slice[..bytes_written], &[0]);
+    assert_eq!(bytes_written, encoded_size);
 
     let decoded: TestWithGeneric<()> =
         bincode::decode_from_slice(&slice[..bytes_written], bincode::config::standard())
@@ -408,12 +437,12 @@ mod zoxide {
     extern crate alloc;
 
     use alloc::borrow::Cow;
-    use bincode::{Decode, Encode};
+    use bincode::{Decode, Encode, EncodedSize};
 
     pub type Rank = f64;
     pub type Epoch = u64;
 
-    #[derive(Encode, Decode)]
+    #[derive(Encode, Decode, EncodedSize)]
     pub struct Dir<'a> {
         pub path: Cow<'a, str>,
         pub rank: Rank,
@@ -436,7 +465,11 @@ mod zoxide {
         ];
         let config = bincode::config::standard();
 
+        let encoded_size = bincode::encoded_size(dirs, config).unwrap();
         let slice = bincode::encode_to_vec(dirs, config).unwrap();
+
+        assert_eq!(slice.len(), encoded_size);
+
         let decoded: Vec<Dir> = bincode::borrow_decode_from_slice(&slice, config).unwrap().0;
 
         assert_eq!(decoded.len(), 2);

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 use alloc::string::String;
 use serde_derive::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, bincode::Encode, bincode::Decode)]
+#[derive(Serialize, Deserialize, bincode::Encode, bincode::Decode, bincode::EncodedSize)]
 pub struct SerdeRoundtrip {
     pub a: u32,
     #[serde(skip)]
@@ -13,7 +13,9 @@ pub struct SerdeRoundtrip {
     pub c: TupleS,
 }
 
-#[derive(Serialize, Deserialize, bincode::Encode, bincode::Decode, PartialEq, Debug)]
+#[derive(
+    Serialize, Deserialize, bincode::Encode, bincode::Decode, bincode::EncodedSize, PartialEq, Debug,
+)]
 pub struct TupleS(f32, f32, f32);
 
 #[test]
@@ -32,16 +34,16 @@ fn test_serde_round_trip() {
     assert_eq!(result.b, 0);
 
     // validate bincode working
-    let bytes = bincode::serde::encode_to_vec(
-        SerdeRoundtrip {
-            a: 15,
-            b: 15,
-            c: TupleS(2.0, 3.0, 4.0),
-        },
-        bincode::config::standard(),
-    )
-    .unwrap();
+    let start = SerdeRoundtrip {
+        a: 15,
+        b: 15,
+        c: TupleS(2.0, 3.0, 4.0),
+    };
+    let encoded_size = bincode::serde::encoded_size(&start, bincode::config::standard()).unwrap();
+    let bytes = bincode::serde::encode_to_vec(start, bincode::config::standard()).unwrap();
+    assert_eq!(bytes.len(), encoded_size);
     assert_eq!(bytes, &[15, 0, 0, 0, 64, 0, 0, 64, 64, 0, 0, 128, 64]);
+
     let (result, len): (SerdeRoundtrip, usize) =
         bincode::serde::decode_from_slice(&bytes, bincode::config::standard()).unwrap();
     assert_eq!(result.a, 15);
@@ -75,8 +77,10 @@ fn test_serialize_deserialize_borrowed_data() {
     ];
 
     let mut result = [0u8; 20];
+    let encoded_size = bincode::serde::encoded_size(&input, bincode::config::standard()).unwrap();
     let len = bincode::serde::encode_into_slice(&input, &mut result, bincode::config::standard())
         .unwrap();
+    assert_eq!(len, encoded_size);
     let result = &result[..len];
     assert_eq!(result, expected);
 
@@ -120,8 +124,10 @@ fn test_serialize_deserialize_owned_data() {
     ];
 
     let mut result = [0u8; 20];
+    let encoded_size = bincode::serde::encoded_size(&input, bincode::config::standard()).unwrap();
     let len = bincode::serde::encode_into_slice(&input, &mut result, bincode::config::standard())
         .unwrap();
+    assert_eq!(len, encoded_size);
     let result = &result[..len];
     assert_eq!(result, expected);
 
@@ -143,7 +149,7 @@ fn test_serialize_deserialize_owned_data() {
 
 #[cfg(feature = "derive")]
 mod derive {
-    use bincode::{Decode, Encode};
+    use bincode::{Decode, Encode, EncodedSize};
     use serde_derive::{Deserialize, Serialize};
 
     #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
@@ -151,13 +157,13 @@ mod derive {
         pub a: u32,
     }
 
-    #[derive(Decode, Encode, PartialEq, Eq, Debug)]
+    #[derive(Decode, Encode, EncodedSize, PartialEq, Eq, Debug)]
     pub struct StructWithSerde {
         #[bincode(with_serde)]
         pub serde: SerdeType,
     }
 
-    #[derive(Decode, Encode, PartialEq, Eq, Debug)]
+    #[derive(Decode, Encode, EncodedSize, PartialEq, Eq, Debug)]
     pub enum EnumWithSerde {
         Unit(#[bincode(with_serde)] SerdeType),
         Struct {
@@ -170,12 +176,18 @@ mod derive {
     fn test_serde_derive() {
         fn test_encode_decode<T>(start: T, expected_len: usize)
         where
-            T: bincode::Encode + bincode::Decode + PartialEq + core::fmt::Debug,
+            T: bincode::Encode
+                + bincode::Decode
+                + bincode::EncodedSize
+                + PartialEq
+                + core::fmt::Debug,
         {
             let mut slice = [0u8; 100];
+            let encoded_size = bincode::encoded_size(&start, bincode::config::standard()).unwrap();
             let len = bincode::encode_into_slice(&start, &mut slice, bincode::config::standard())
                 .unwrap();
             assert_eq!(len, expected_len);
+            assert_eq!(len, encoded_size);
             let slice = &slice[..len];
             let (result, len): (T, usize) =
                 bincode::decode_from_slice(slice, bincode::config::standard()).unwrap();


### PR DESCRIPTION
Related issue: #539 

Hi bincode developers.  This is the first in a series of 3 PRs that would allow us to replace our current use of [Abomonation](https://github.com/TimelyDataflow/abomonation/) with bincode, without a noticeable performance hit.  We'd like these to be adopted upstream, and hope they are useful for other users of bincode also.

For some storage back-ends it's necessary to know the size of the buffer to pre-allocate before encoding.  This is true of our cache back-end, which is C++ code that we communicate with over FFI.  The bincode 1.0 version had `bincode::serialized_size`, which would tell you the serialized size of data, but for bincode 2.0 this is not implemented.

One suggestion is to implement a `SizeOnlyWriter` which adds up the sizes of the slices it's been given, however this effectively requires serializing the data twice, as it doesn't allow types to efficiently compute the size when it is possible to do so without performing the actual serialization steps.

In this PR, we add a new `EncodedSize` trait which accomplishes this objective, and implement that for all types.  Implementations for custom structs and enums can be derived using `#[derive(bincode::EncodedSize)]`.