### PR TITLE
Implement support for smallvec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,12 @@ default = ["std", "derive"]
 std = ["alloc", "serde?/std"]
 alloc = ["serde?/alloc"]
 derive = ["bincode_derive"]
+smallvec = ["dep:smallvec"]
 
 [dependencies]
 bincode_derive = { path = "derive", version = "2.0.0-rc.2", optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
+smallvec = { version = "1.0", optional = true }
 
 # Used for tests
 [dev-dependencies]

--- a/src/features/impl_smallvec.rs
+++ b/src/features/impl_smallvec.rs
@@ -1,0 +1,63 @@
+use crate::de::BorrowDecoder;
+use crate::de::Decode;
+use crate::de::Decoder;
+use crate::enc::Encode;
+use crate::enc::Encoder;
+use crate::error::DecodeError;
+use crate::error::EncodeError;
+use crate::BorrowDecode;
+use smallvec::{Array, SmallVec};
+
+impl<A> Decode for SmallVec<A>
+where
+    A: Array,
+    A::Item: Decode,
+{
+    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+        let len = crate::de::decode_slice_len(decoder)?;
+        decoder.claim_container_read::<A::Item>(len)?;
+
+        let mut vec = SmallVec::with_capacity(len);
+        for _ in 0..len {
+            // See the documentation on `unclaim_bytes_read` as to why we're doing this here
+            decoder.unclaim_bytes_read(core::mem::size_of::<A::Item>());
+
+            vec.push(A::Item::decode(decoder)?);
+        }
+        Ok(vec)
+    }
+}
+
+impl<'de, A> BorrowDecode<'de> for SmallVec<A>
+where
+    A: Array,
+    A::Item: BorrowDecode<'de>,
+{
+    fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
+        let len = crate::de::decode_slice_len(decoder)?;
+        decoder.claim_container_read::<A::Item>(len)?;
+
+        let mut vec = SmallVec::with_capacity(len);
+        for _ in 0..len {
+            // See the documentation on `unclaim_bytes_read` as to why we're doing this here
+            decoder.unclaim_bytes_read(core::mem::size_of::<A::Item>());
+
+            vec.push(A::Item::borrow_decode(decoder)?);
+        }
+        Ok(vec)
+    }
+}
+
+impl<A> Encode for SmallVec<A>
+where
+    A: Array,
+    A::Item: Encode,
+{
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        crate::enc::encode_slice_len(encoder, self.len())?;
+        for item in self.iter() {
+            item.encode(encoder)?;
+        }
+        Ok(())
+    }
+}

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -16,3 +16,7 @@ pub use self::derive::*;
 #[cfg(feature = "serde")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 pub mod serde;
+
+#[cfg(feature = "smallvec")]
+#[cfg_attr(docsrs, doc(cfg(feature = "smallvec")))]
+mod impl_smallvec;

--- a/tests/smallvec.rs
+++ b/tests/smallvec.rs
@@ -1,0 +1,29 @@
+#![cfg(feature = "smallvec")]
+
+use smallvec::{smallvec, SmallVec};
+
+#[test]
+fn test_smallvec() {
+    let start: SmallVec<[u32; 8]> = smallvec![5, 6, 7, 8];
+
+    let data = bincode::encode_to_vec(&start, bincode::config::standard()).unwrap();
+
+    let decoded_unspilled: SmallVec<[u32; 8]> =
+        bincode::decode_from_slice(&data, bincode::config::standard())
+            .unwrap()
+            .0;
+    assert_eq!(start, decoded_unspilled);
+
+    // SmallVec backing array size doesn't actually matter
+    let decoded_spilled: SmallVec<[u32; 2]> =
+        bincode::decode_from_slice(&data, bincode::config::standard())
+            .unwrap()
+            .0;
+    assert_eq!(start, decoded_spilled);
+
+    // And, in fact, we can even decode as a Vec
+    let decoded_vec: Vec<u32> = bincode::decode_from_slice(&data, bincode::config::standard())
+        .unwrap()
+        .0;
+    assert_eq!(start.as_slice(), decoded_vec.as_slice());
+}


### PR DESCRIPTION
Hi bincode developers. This is the second in a series of 3 PRs that would allow us to replace our current use of [Abomonation](https://github.com/TimelyDataflow/abomonation/) with bincode, without a noticeable performance hit. We'd like these to be adopted upstream, and hope they are useful for other users of bincode also.

We use `SmallVec` in a number of places in the structures that we serialize, as this gives us a noticeable memory footprint and performance improvement.  Rust's orphan rule prevents us from implementing the bincode traits for `SmallVec` ourselves, as it's defined in a different crate.  Instead, we propose adding a new optional feature to bincode with implements the traits for that type when enabled.  When the `smallvec` feature is specified, bincode additionally provides implementations of `Encode` and `Decode` for `SmallVec`, much like it already does for the standard library types.