### PR TITLE
Improved encoding and decoding speed of Vec<u8>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ rand = "0.8"
 uuid = { version = "1.1", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 glam = { version = "0.21", features = ["serde"] }
+bincode_1 = { version = "1.3", package = "bincode" }
+serde = { version = "1.0", features = ["derive"] }
 
 [[bench]]
 name = "varint"
@@ -53,9 +55,14 @@ harness = false
 name = "inline"
 harness = false
 
+[[bench]]
+name = "string"
+harness = false
+
 [profile.bench]
 codegen-units = 1
 debug = 1
+lto = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/benches/string.rs
+++ b/benches/string.rs
@@ -1,7 +1,7 @@
 // https://github.com/bincode-org/bincode/issues/618
 
 use bincode::{Decode, Encode};
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Default, Encode, Decode)]
@@ -32,21 +32,21 @@ fn index_item_decode(c: &mut Criterion) {
 
     c.bench_function("bench v1", |b| {
         b.iter(|| {
-            let _ = bincode_1::serialize(&data).unwrap();
+            let _ = black_box(bincode_1::serialize(black_box(&data))).unwrap();
         });
     });
 
     let config = bincode::config::standard();
     c.bench_function("bench v2 (standard)", |b| {
         b.iter(|| {
-            let _ = bincode::encode_to_vec(&data, config).unwrap();
+            let _ = black_box(bincode::encode_to_vec(black_box(&data), config)).unwrap();
         });
     });
 
     let config = bincode::config::legacy();
     c.bench_function("bench v2 (legacy)", |b| {
         b.iter(|| {
-            let _ = bincode::encode_to_vec(&data, config).unwrap();
+            let _ = black_box(bincode::encode_to_vec(black_box(&data), config)).unwrap();
         });
     });
 
@@ -56,13 +56,15 @@ fn index_item_decode(c: &mut Criterion) {
 
     c.bench_function("bench v1 decode", |b| {
         b.iter(|| {
-            let _: Vec<MyStruct> = bincode_1::deserialize(&encodedv1).unwrap();
+            let _: Vec<MyStruct> =
+                black_box(bincode_1::deserialize(black_box(&encodedv1))).unwrap();
         });
     });
 
     c.bench_function("bench v2 decode (legacy)", |b| {
         b.iter(|| {
-            let _: (Vec<MyStruct>, _) = bincode::decode_from_slice(&encodedv1, config).unwrap();
+            let _: (Vec<MyStruct>, _) =
+                black_box(bincode::decode_from_slice(black_box(&encodedv1), config)).unwrap();
         });
     });
 }

--- a/benches/string.rs
+++ b/benches/string.rs
@@ -1,0 +1,71 @@
+// https://github.com/bincode-org/bincode/issues/618
+
+use bincode::{Decode, Encode};
+use criterion::{criterion_group, criterion_main, Criterion};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Default, Encode, Decode)]
+pub struct MyStruct {
+    pub v: Vec<String>,
+    pub string: String,
+    pub number: usize,
+}
+
+impl MyStruct {
+    #[inline]
+    pub fn new(v: Vec<String>, string: String, number: usize) -> Self {
+        Self { v, string, number }
+    }
+}
+
+fn build_data(size: usize) -> Vec<MyStruct> {
+    (0..size)
+        .map(|i| {
+            let vec: Vec<String> = (0..i).map(|i| i.to_string().repeat(100)).collect();
+            MyStruct::new(vec, size.to_string(), size)
+        })
+        .collect()
+}
+
+fn index_item_decode(c: &mut Criterion) {
+    let data = build_data(100);
+
+    c.bench_function("bench v1", |b| {
+        b.iter(|| {
+            let _ = bincode_1::serialize(&data).unwrap();
+        });
+    });
+
+    let config = bincode::config::standard();
+    c.bench_function("bench v2 (standard)", |b| {
+        b.iter(|| {
+            let _ = bincode::encode_to_vec(&data, config).unwrap();
+        });
+    });
+
+    let config = bincode::config::legacy();
+    c.bench_function("bench v2 (legacy)", |b| {
+        b.iter(|| {
+            let _ = bincode::encode_to_vec(&data, config).unwrap();
+        });
+    });
+
+    let encodedv1 = bincode_1::serialize(&data).unwrap();
+    let encodedv2 = bincode::encode_to_vec(&data, config).unwrap();
+    assert_eq!(encodedv1, encodedv2);
+
+    c.bench_function("bench v1 decode", |b| {
+        b.iter(|| {
+            let _: Vec<MyStruct> = bincode_1::deserialize(&encodedv1).unwrap();
+        });
+    });
+
+    c.bench_function("bench v2 decode (legacy)", |b| {
+        b.iter(|| {
+            let _: (Vec<MyStruct>, _) = bincode::decode_from_slice(&encodedv1, config).unwrap();
+        });
+    });
+}
+
+criterion_group!(benches, index_item_decode);
+criterion_main!(benches);

--- a/src/enc/encoder.rs
+++ b/src/enc/encoder.rs
@@ -32,6 +32,7 @@ impl<W: Writer, C: Config> EncoderImpl<W, C> {
     }
 
     /// Return the underlying writer
+    #[inline]
     pub fn into_writer(self) -> W {
         self.writer
     }
@@ -42,10 +43,12 @@ impl<W: Writer, C: Config> Encoder for EncoderImpl<W, C> {
 
     type C = C;
 
+    #[inline]
     fn writer(&mut self) -> &mut Self::W {
         &mut self.writer
     }
 
+    #[inline]
     fn config(&self) -> &Self::C {
         &self.config
     }

--- a/src/enc/impls.rs
+++ b/src/enc/impls.rs
@@ -295,10 +295,17 @@ impl Encode for char {
 
 impl<T> Encode for [T]
 where
-    T: Encode,
+    T: Encode + 'static,
 {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
         super::encode_slice_len(encoder, self.len())?;
+
+        if core::any::TypeId::of::<T>() == core::any::TypeId::of::<u8>() {
+            let t: &[u8] = unsafe { core::mem::transmute(self) };
+            encoder.writer().write(t)?;
+            return Ok(());
+        }
+
         for item in self {
             item.encode(encoder)?;
         }

--- a/src/enc/write.rs
+++ b/src/enc/write.rs
@@ -65,3 +65,18 @@ impl<'storage> Writer for SliceWriter<'storage> {
         Ok(())
     }
 }
+
+/// A writer that counts how many bytes were written. This is useful for e.g. pre-allocating buffers bfeore writing to them.
+#[derive(Default)]
+pub struct SizeWriter {
+    /// the amount of bytes that were written so far
+    pub bytes_written: usize,
+}
+impl Writer for SizeWriter {
+    #[inline(always)]
+    fn write(&mut self, bytes: &[u8]) -> Result<(), EncodeError> {
+        self.bytes_written += bytes.len();
+
+        Ok(())
+    }
+}

--- a/src/features/impl_alloc.rs
+++ b/src/features/impl_alloc.rs
@@ -1,6 +1,10 @@
 use crate::{
     de::{read::Reader, BorrowDecoder, Decode, Decoder},
-    enc::{self, write::Writer, Encode, Encoder},
+    enc::{
+        self,
+        write::{SizeWriter, Writer},
+        Encode, Encoder,
+    },
     error::{DecodeError, EncodeError},
     impl_borrow_decode, BorrowDecode, Config,
 };
@@ -21,6 +25,12 @@ pub(crate) struct VecWriter {
 }
 
 impl VecWriter {
+    /// Create a new vec writer with the given capacity
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            inner: Vec::with_capacity(cap),
+        }
+    }
     // May not be used in all feature combinations
     #[allow(dead_code)]
     pub(crate) fn collect(self) -> Vec<u8> {
@@ -29,6 +39,7 @@ impl VecWriter {
 }
 
 impl enc::write::Writer for VecWriter {
+    #[inline(always)]
     fn write(&mut self, bytes: &[u8]) -> Result<(), EncodeError> {
         self.inner.extend_from_slice(bytes);
         Ok(())
@@ -40,7 +51,12 @@ impl enc::write::Writer for VecWriter {
 /// [config]: config/index.html
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub fn encode_to_vec<E: enc::Encode, C: Config>(val: E, config: C) -> Result<Vec<u8>, EncodeError> {
-    let writer = VecWriter::default();
+    let size = {
+        let mut size_writer = enc::EncoderImpl::<_, C>::new(SizeWriter::default(), config);
+        val.encode(&mut size_writer)?;
+        size_writer.into_writer().bytes_written
+    };
+    let writer = VecWriter::with_capacity(size);
     let mut encoder = enc::EncoderImpl::<_, C>::new(writer, config);
     val.encode(&mut encoder)?;
     Ok(encoder.into_writer().inner)
@@ -274,7 +290,7 @@ where
             vec.resize(len, 0u8);
             decoder.reader().read(&mut vec)?;
             // Safety: Vec<T> is Vec<u8>
-            return Ok(unsafe { std::mem::transmute(vec) });
+            return Ok(unsafe { core::mem::transmute(vec) });
         }
         decoder.claim_container_read::<T>(len)?;
 

--- a/src/features/impl_alloc.rs
+++ b/src/features/impl_alloc.rs
@@ -331,10 +331,7 @@ where
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
         crate::enc::encode_slice_len(encoder, self.len())?;
         if core::any::TypeId::of::<T>() == core::any::TypeId::of::<u8>() {
-            // Safety: We just asserted that T == u8, so &[T] == &[u8]
-            // so we can cast to a &[u8] slice safely
-            let slice: &[u8] =
-                unsafe { core::slice::from_raw_parts(self.as_ptr().cast(), self.len()) };
+            let slice: &[u8] = unsafe { core::mem::transmute(self.as_slice()) };
             encoder.writer().write(slice)?;
             return Ok(());
         }


### PR DESCRIPTION
Running against the benchmarks in #618 

```
bench v1                time:   [48.663 µs 49.119 µs 49.573 µs]
                        change: [-0.9286% +0.8850% +2.7884%] (p = 0.35 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe

bench v2 (standard)     time:   [642.39 µs 646.82 µs 651.41 µs]
                        change: [-71.758% -71.415% -71.093%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

bench v2 (legacy)       time:   [650.62 µs 653.72 µs 656.93 µs]
                        change: [-71.322% -71.089% -70.844%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

bench v1 decode         time:   [301.58 µs 302.76 µs 303.97 µs]
                        change: [-42.809% -40.022% -36.789%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe

bench v2 decode (legacy)
                        time:   [326.89 µs 328.24 µs 329.63 µs]
                        change: [-81.836% -81.650% -81.457%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) low mild
  2 (2.00%) high mild
```

decoding seems to be on-par with bincode 1 now. Encoding is down to being a factor 10 slower.