### PR TITLE
embedded-io compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,14 @@ edition = "2021"
 [features]
 default = ["std", "derive"]
 std = ["alloc", "serde?/std"]
+embedded-io = ["dep:embedded-io"]
 alloc = ["serde?/alloc"]
 derive = ["bincode_derive"]
 
 [dependencies]
 bincode_derive = { path = "derive", version = "2.0.0-rc.3", optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
+embedded-io = { version = "0.4", optional = true }
 
 # Used for tests
 [dev-dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@ pub enum EncodeError {
     /// The writer ran out of storage.
     UnexpectedEnd,
 
-    /// The RefCell<T> is already borrowed
+    /// The `RefCell<T>` is already borrowed
     RefCellAlreadyBorrowed {
         /// The inner borrow error
         inner: core::cell::BorrowError,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-//! Errors that can be encounting by Encoding and Decoding.
+//! Errors that can be encountered by Encoding and Decoding.
 
 /// Errors that can be encountered by encoding a type
 #[non_exhaustive]
@@ -27,11 +27,17 @@ pub enum EncodeError {
     InvalidPathCharacters,
 
     /// The targeted writer encountered an `std::io::Error`
-    #[cfg(any(feature = "std", feature = "embedded-io"))]
+    #[cfg(feature = "std")]
     Io {
         /// The encountered error
-        #[cfg(feature = "std")]
         inner: std::io::Error,
+        /// The amount of bytes that were written before the error occurred
+        index: usize,
+    },
+
+    /// The targeted writer encountered an `std::io::Error`
+    #[cfg(feature = "embedded-io")]
+    EmbeddedIo {
         /// The amount of bytes that were written before the error occurred
         index: usize,
     },
@@ -166,12 +172,22 @@ pub enum DecodeError {
     },
 
     /// The reader encountered an IO error but more bytes were expected.
-    #[cfg(any(feature = "std", feature = "embedded-io"))]
+    #[cfg(feature = "std")]
     Io {
         /// The IO error expected
-        #[cfg(feature = "std")]
         inner: std::io::Error,
 
+        /// Gives an estimate of how many extra bytes are needed.
+        ///
+        /// **Note**: this is only an estimate and not indicative of the actual bytes needed.
+        ///
+        /// **Note**: Bincode has no look-ahead mechanism. This means that this will only return the amount of bytes to be read for the current action, and not take into account the entire data structure being read.
+        additional: usize,
+    },
+
+    /// The reader encountered an IO error but more bytes were expected.
+    #[cfg(feature = "embedded-io")]
+    EmbeddedIo {
         /// Gives an estimate of how many extra bytes are needed.
         ///
         /// **Note**: this is only an estimate and not indicative of the actual bytes needed.

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,9 +27,10 @@ pub enum EncodeError {
     InvalidPathCharacters,
 
     /// The targeted writer encountered an `std::io::Error`
-    #[cfg(feature = "std")]
+    #[cfg(any(feature = "std", feature = "embedded-io"))]
     Io {
         /// The encountered error
+        #[cfg(feature = "std")]
         inner: std::io::Error,
         /// The amount of bytes that were written before the error occurred
         index: usize,
@@ -165,9 +166,10 @@ pub enum DecodeError {
     },
 
     /// The reader encountered an IO error but more bytes were expected.
-    #[cfg(feature = "std")]
+    #[cfg(any(feature = "std", feature = "embedded-io"))]
     Io {
         /// The IO error expected
+        #[cfg(feature = "std")]
         inner: std::io::Error,
 
         /// Gives an estimate of how many extra bytes are needed.

--- a/src/features/impl_embedded_io.rs
+++ b/src/features/impl_embedded_io.rs
@@ -1,0 +1,93 @@
+use crate::{
+    config::Config,
+    de::{read::Reader, Decode, DecoderImpl},
+    enc::{write::Writer, Encode, EncoderImpl},
+    error::{DecodeError, EncodeError},
+};
+
+/// Decode type `D` from the given reader with the given `Config`. The reader can be any type that implements `embedded_io::blocking::Read`, e.g. `std::fs::File`.
+///
+/// See the [config] module for more information about config options.
+///
+/// [config]: config/index.html
+#[cfg_attr(docsrs, doc(cfg(feature = "embedded-io")))]
+pub fn decode_from_embedded_io_read<D: Decode, C: Config, R: embedded_io::blocking::Read>(
+    src: &mut R,
+    config: C,
+) -> Result<D, DecodeError> {
+    let reader = EmbeddedIoReader::new(src);
+    let mut decoder = DecoderImpl::<_, C>::new(reader, config);
+    D::decode(&mut decoder)
+}
+
+pub(crate) struct EmbeddedIoReader<R> {
+    reader: R,
+}
+
+impl<R> EmbeddedIoReader<R> {
+    pub fn new(reader: R) -> Self {
+        Self { reader }
+    }
+}
+
+impl<R> Reader for EmbeddedIoReader<R>
+where
+    R: embedded_io::blocking::Read,
+{
+    #[inline(always)]
+    fn read(&mut self, bytes: &mut [u8]) -> Result<(), DecodeError> {
+        self.reader
+            .read_exact(bytes)
+            .map_err(|_inner| DecodeError::Io {
+                additional: bytes.len(),
+            })
+    }
+}
+
+/// Encode the given value into any type that implements `embedded_io::blocking::Write`, e.g. `std::fs::File`, with the given `Config`.
+/// See the [config] module for more information.
+/// Returns the amount of bytes written.
+///
+/// [config]: config/index.html
+#[cfg_attr(docsrs, doc(cfg(feature = "embedded-io")))]
+pub fn encode_into_embedded_io_write<E: Encode, C: Config, W: embedded_io::blocking::Write>(
+    val: E,
+    dst: &mut W,
+    config: C,
+) -> Result<usize, EncodeError> {
+    let writer = IoWriter::new(dst);
+    let mut encoder = EncoderImpl::<_, C>::new(writer, config);
+    val.encode(&mut encoder)?;
+    Ok(encoder.into_writer().bytes_written())
+}
+
+pub(crate) struct IoWriter<'a, W: embedded_io::blocking::Write> {
+    writer: &'a mut W,
+    bytes_written: usize,
+}
+
+impl<'a, W: embedded_io::blocking::Write> IoWriter<'a, W> {
+    pub fn new(writer: &'a mut W) -> Self {
+        Self {
+            writer,
+            bytes_written: 0,
+        }
+    }
+
+    pub fn bytes_written(&self) -> usize {
+        self.bytes_written
+    }
+}
+
+impl<'storage, W: embedded_io::blocking::Write> Writer for IoWriter<'storage, W> {
+    #[inline(always)]
+    fn write(&mut self, bytes: &[u8]) -> Result<(), EncodeError> {
+        self.writer
+            .write_all(bytes)
+            .map_err(|_inner| EncodeError::Io {
+                index: self.bytes_written,
+            })?;
+        self.bytes_written += bytes.len();
+        Ok(())
+    }
+}

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -8,6 +8,11 @@ mod impl_std;
 #[cfg(feature = "std")]
 pub use self::impl_std::*;
 
+#[cfg(feature = "embedded-io")]
+mod impl_embedded_io;
+#[cfg(feature = "embedded-io")]
+pub use self::impl_embedded_io::*;
+
 #[cfg(feature = "derive")]
 mod derive;
 #[cfg(feature = "derive")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,13 +15,14 @@
 //!
 //! # Features
 //!
-//! |Name  |Default?|Supported types for Encode/Decode|Enabled methods                                                  |Other|
-//! |------|--------|-----------------------------------------|-----------------------------------------------------------------|-----|
-//! |std   | Yes    |`HashMap` and `HashSet`|`decode_from_std_read` and `encode_into_std_write`|
-//! |alloc | Yes    |All common containers in alloc, like `Vec`, `String`, `Box`|`encode_to_vec`|
-//! |atomic| Yes    |All `Atomic*` integer types, e.g. `AtomicUsize`, and `AtomicBool`||
-//! |derive| Yes    |||Enables the `BorrowDecode`, `Decode` and `Encode` derive macros|
-//! |serde | No     |`Compat` and `BorrowCompat`, which will work for all types that implement serde's traits|serde-specific encode/decode functions in the [serde] module|Note: There are several [known issues](serde/index.html#known-issues) when using serde and bincode|
+//! |Name       |Default?|Supported types for Encode/Decode|Enabled methods                                                  |Other|
+//! |-----------|--------|-----------------------------------------|-----------------------------------------------------------------|-----|
+//! |std        | Yes    |`HashMap` and `HashSet`|`decode_from_std_read` and `encode_into_std_write`|
+//! |alloc      | Yes    |All common containers in alloc, like `Vec`, `String`, `Box`|`encode_to_vec`|
+//! |atomic     | Yes    |All `Atomic*` integer types, e.g. `AtomicUsize`, and `AtomicBool`||
+//! |derive     | Yes    |||Enables the `BorrowDecode`, `Decode` and `Encode` derive macros|
+//! |serde      | No     |`Compat` and `BorrowCompat`, which will work for all types that implement serde's traits|serde-specific encode/decode functions in the [serde] module|Note: There are several [known issues](serde/index.html#known-issues) when using serde and bincode|
+//! |embedded-io| No     |No new types|`decode_from_embedded_io_read`, `encode_into_embedded_io_write`|Io errors are mapped to the `EmbeddedIo` error variant
 //!
 //! # Which functions to use
 //!
@@ -74,9 +75,6 @@
 #![doc(html_root_url = "https://docs.rs/bincode/2.0.0-rc.3")]
 #![crate_name = "bincode"]
 #![crate_type = "rlib"]
-
-#[cfg(all(feature = "std", feature = "embedded-io"))]
-compiler_error!("Cannot enable both the `std` and `embedded-io` features at the same time");
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,9 @@
 #![crate_name = "bincode"]
 #![crate_type = "rlib"]
 
+#[cfg(all(feature = "std", feature = "embedded-io"))]
+compiler_error!("Cannot enable both the `std` and `embedded-io` features at the same time");
+
 #[cfg(feature = "alloc")]
 extern crate alloc;
 #[cfg(any(feature = "std", test))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,10 +19,10 @@
 //! |-----------|--------|-----------------------------------------|-----------------------------------------------------------------|-----|
 //! |std        | Yes    |`HashMap` and `HashSet`|`decode_from_std_read` and `encode_into_std_write`|
 //! |alloc      | Yes    |All common containers in alloc, like `Vec`, `String`, `Box`|`encode_to_vec`|
+//! |embedded-io| No     ||`decode_from_embedded_io_read`, `encode_into_embedded_io_write`|Io errors are mapped to the `EmbeddedIo` error variant
 //! |atomic     | Yes    |All `Atomic*` integer types, e.g. `AtomicUsize`, and `AtomicBool`||
 //! |derive     | Yes    |||Enables the `BorrowDecode`, `Decode` and `Encode` derive macros|
 //! |serde      | No     |`Compat` and `BorrowCompat`, which will work for all types that implement serde's traits|serde-specific encode/decode functions in the [serde] module|Note: There are several [known issues](serde/index.html#known-issues) when using serde and bincode|
-//! |embedded-io| No     |No new types|`decode_from_embedded_io_read`, `encode_into_embedded_io_write`|Io errors are mapped to the `EmbeddedIo` error variant
 //!
 //! # Which functions to use
 //!


### PR DESCRIPTION
Resolves #652

I'm opening this PR early because I have a few open questions:
 - embedded-io traits have an associated error type for IO errors. How should we incorporate this?
   - we can make EncodeError/DecodeError generic, and default to std::io::Error
   - we can introduce a custom io error type, map known std errors to it, and map embedded-io errors to EOF (ReadExact error) or Other.
 - `decode_from_embedded_io_read` is a bit verbose. I think I'd try to create a single encode/decode function and abstract the std/embedded options with a bincode-provided marker trait. The implementation would be more complex, but the API would be simpler. What is your preference here?

Right now we can't have both std and embedded-io features active, because of the IO error question. I intend this as a temporary restriction and plan on lifting it if the resolution of that question allows.