### PR TITLE
Use const functions where possible

### DIFF
--- a/src/de/decoder.rs
+++ b/src/de/decoder.rs
@@ -28,7 +28,7 @@ pub struct DecoderImpl<R, C: Config> {
 
 impl<R: Reader, C: Config> DecoderImpl<R, C> {
     /// Construct a new Decoder
-    pub fn new(reader: R, config: C) -> DecoderImpl<R, C> {
+    pub const fn new(reader: R, config: C) -> DecoderImpl<R, C> {
         DecoderImpl {
             reader,
             config,

--- a/src/de/read.rs
+++ b/src/de/read.rs
@@ -66,7 +66,7 @@ pub struct SliceReader<'storage> {
 
 impl<'storage> SliceReader<'storage> {
     /// Constructs a slice reader
-    pub fn new(bytes: &'storage [u8]) -> SliceReader<'storage> {
+    pub const fn new(bytes: &'storage [u8]) -> SliceReader<'storage> {
         SliceReader { slice: bytes }
     }
 }

--- a/src/enc/encoder.rs
+++ b/src/enc/encoder.rs
@@ -27,7 +27,7 @@ pub struct EncoderImpl<W: Writer, C: Config> {
 
 impl<W: Writer, C: Config> EncoderImpl<W, C> {
     /// Create a new Encoder
-    pub fn new(writer: W, config: C) -> EncoderImpl<W, C> {
+    pub const fn new(writer: W, config: C) -> EncoderImpl<W, C> {
         EncoderImpl { writer, config }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -250,7 +250,7 @@ pub enum IntegerType {
 impl IntegerType {
     /// Change the `Ux` value to the associated `Ix` value.
     /// Returns the old value if `self` is already `Ix`.
-    pub(crate) fn into_signed(self) -> Self {
+    pub(crate) const fn into_signed(self) -> Self {
         match self {
             Self::U8 => Self::I8,
             Self::U16 => Self::I16,

--- a/src/features/impl_std.rs
+++ b/src/features/impl_std.rs
@@ -37,7 +37,7 @@ pub(crate) struct IoReader<R> {
 }
 
 impl<R> IoReader<R> {
-    pub fn new(reader: R) -> Self {
+    pub const fn new(reader: R) -> Self {
         Self { reader }
     }
 }
@@ -109,7 +109,7 @@ impl<'a, W: std::io::Write> IoWriter<'a, W> {
         }
     }
 
-    pub fn bytes_written(&self) -> usize {
+    pub const fn bytes_written(&self) -> usize {
         self.bytes_written
     }
 }

--- a/src/varint/decode_unsigned.rs
+++ b/src/varint/decode_unsigned.rs
@@ -190,7 +190,7 @@ where
 
 #[inline(never)]
 #[cold]
-fn invalid_varint_discriminant<T>(
+const fn invalid_varint_discriminant<T>(
     expected: IntegerType,
     found: IntegerType,
 ) -> Result<T, DecodeError> {


### PR DESCRIPTION
I just used clippy for this. I actually assume that you will not want the brunt of this change but I figured it was easier to make the change everywhere then simply pick the ones you deem acceptable (if any).

I definitey think some of the constructors should be `const`. 

Thanks in advance!

