### PR TITLE
Add LICENSE.md to derive/

### DIFF
--- a/derive/LICENSE.md
+++ b/derive/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md


### PR DESCRIPTION
Adds a symlink from derive/LICENSE.md back to the LICENSE.md file in the root of the repository.  Since bincode_derive is published as a separate crate, this ensures the license is bundled appropriately with the crate.