### PR TITLE
Add (optional) smallvec decode/encode support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,13 @@ default = ["std", "derive"]
 std = ["alloc", "serde?/std"]
 alloc = ["serde?/alloc"]
 derive = ["bincode_derive"]
+smallvec = ["dep:smallvec"]
 
 [dependencies]
 bincode_derive = { path = "derive", version = "2.0.0-rc.3", optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 unty = "0.0.3"
+smallvec = { version = "1.13.1", default-features = false, optional = true}
 
 # Used for tests
 [dev-dependencies]


### PR DESCRIPTION
I added optional support for the smallvec crate which supports vectors inside a struct without a separate memory allocation. I tried implementing this with the newtype pattern, but i could not figure out a way to deserialise a without going via a vector (and thus allocating the memory that the crate was designed to avoid). 

The code is 90% copy paste from the code for (De)coding vectors. However I had to remove the optimisation for deserialising u8 as SmallVec don't use generics for the array size.

I hope that this change can be merged, and am happy to work with you if there are any changes that are needed in order to do so.

We probably also need to update the list of features in the docs. I can do that if necessary.