### PR TITLE
Decode context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ chrono = { version = "0.4", features = ["serde"] }
 glam = { version = "0.25", features = ["serde"] }
 bincode_1 = { version = "1.3", package = "bincode" }
 serde = { version = "1.0", features = ["derive"] }
+bumpalo = { version = "3.16.0", features = ["collections"] }
 
 [[bench]]
 name = "varint"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ unty = "0.0.3"
 
 # Used for tests
 [dev-dependencies]
+ouroboros = "0.18.3"
 serde_derive = "1.0"
 serde_json = { version = "1.0", default-features = false }
 tempfile = "3.2"

--- a/compatibility/src/lib.rs
+++ b/compatibility/src/lib.rs
@@ -11,7 +11,7 @@ mod sway;
 pub fn test_same_with_config<T, C, O>(t: &T, bincode_1_options: O, bincode_2_config: C)
 where
     T: bincode_2::Encode
-        + bincode_2::Decode
+        + bincode_2::Decode<()>
         + serde::Serialize
         + serde::de::DeserializeOwned
         + core::fmt::Debug
@@ -60,7 +60,7 @@ where
 pub fn test_same<T>(t: T)
 where
     T: bincode_2::Encode
-        + bincode_2::Decode
+        + bincode_2::Decode<()>
         + serde::Serialize
         + serde::de::DeserializeOwned
         + core::fmt::Debug

--- a/compatibility/src/sway.rs
+++ b/compatibility/src/sway.rs
@@ -32,6 +32,7 @@ pub enum FTXresponse<T> {
     Error(FTXresponseFailure),
 }
 
+
 #[derive(
     bincode_2::Encode, bincode_2::Decode, serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq,
 )]

--- a/derive/src/attribute.rs
+++ b/derive/src/attribute.rs
@@ -1,4 +1,3 @@
-use proc_macro::Literal;
 use virtue::prelude::*;
 use virtue::utils::{parse_tagged_attribute, ParsedAttribute};
 

--- a/derive/src/attribute.rs
+++ b/derive/src/attribute.rs
@@ -1,3 +1,4 @@
+use proc_macro::Literal;
 use virtue::prelude::*;
 use virtue::utils::{parse_tagged_attribute, ParsedAttribute};
 
@@ -5,6 +6,7 @@ pub struct ContainerAttributes {
     pub crate_name: String,
     pub bounds: Option<(String, Literal)>,
     pub decode_bounds: Option<(String, Literal)>,
+    pub decode_context: Option<(String, Literal)>,
     pub borrow_decode_bounds: Option<(String, Literal)>,
     pub encode_bounds: Option<(String, Literal)>,
 }
@@ -15,6 +17,7 @@ impl Default for ContainerAttributes {
             crate_name: "::bincode".to_string(),
             bounds: None,
             decode_bounds: None,
+            decode_context: None,
             encode_bounds: None,
             borrow_decode_bounds: None,
         }
@@ -51,6 +54,15 @@ impl FromAttribute for ContainerAttributes {
                     let val_string = val.to_string();
                     if val_string.starts_with('"') && val_string.ends_with('"') {
                         result.decode_bounds =
+                            Some((val_string[1..val_string.len() - 1].to_string(), val));
+                    } else {
+                        return Err(Error::custom_at("Should be a literal str", val.span()));
+                    }
+                }
+                ParsedAttribute::Property(key, val) if key.to_string() == "decode_context" => {
+                    let val_string = val.to_string();
+                    if val_string.starts_with('"') && val_string.ends_with('"') {
+                        result.decode_context =
                             Some((val_string[1..val_string.len() - 1].to_string(), val));
                     } else {
                         return Err(Error::custom_at("Should be a literal str", val.span()));

--- a/derive/src/derive_enum.rs
+++ b/derive/src/derive_enum.rs
@@ -222,7 +222,7 @@ impl DeriveEnum {
         let decode_context = if let Some((decode_context, _)) = &self.attributes.decode_context {
             decode_context.as_str()
         } else {
-            "__Ctx"
+            "__Context"
         };
         // Remember to keep this mostly in sync with generate_borrow_decode
 
@@ -231,7 +231,7 @@ impl DeriveEnum {
         let mut impl_for = generator.impl_for(format!("{}::Decode", crate_name));
 
         if self.attributes.decode_context.is_none() {
-            impl_for = impl_for.with_impl_generics(["__Ctx"]);
+            impl_for = impl_for.with_impl_generics(["__Context"]);
         }
 
         impl_for
@@ -242,7 +242,7 @@ impl DeriveEnum {
                     where_constraints.push_parsed_constraint(bounds).map_err(|e| e.with_span(lit.span()))?;
                 } else {
                     for g in generics.iter_generics() {
-                        where_constraints.push_constraint(g, format!("{}::Decode<__Ctx>", crate_name))?;
+                        where_constraints.push_constraint(g, format!("{}::Decode<__Context>", crate_name))?;
                     }
                 }
                 Ok(())
@@ -332,7 +332,7 @@ impl DeriveEnum {
         let decode_context = if let Some((decode_context, _)) = &self.attributes.decode_context {
             decode_context.as_str()
         } else {
-            "__Ctx"
+            "__Context"
         };
 
         // Remember to keep this mostly in sync with generate_decode
@@ -342,7 +342,7 @@ impl DeriveEnum {
             .impl_for_with_lifetimes(format!("{}::BorrowDecode", crate_name), ["__de"])
             .with_trait_generics([decode_context]);
         if self.attributes.decode_context.is_none() {
-            impl_for = impl_for.with_impl_generics(["__Ctx"]);
+            impl_for = impl_for.with_impl_generics(["__Context"]);
         }
 
         impl_for

--- a/derive/src/derive_enum.rs
+++ b/derive/src/derive_enum.rs
@@ -230,7 +230,6 @@ impl DeriveEnum {
 
         let mut impl_for = generator.impl_for(format!("{}::Decode", crate_name));
 
-
         if self.attributes.decode_context.is_none() {
             impl_for = impl_for.with_impl_generics(["__Ctx"]);
         }
@@ -249,7 +248,7 @@ impl DeriveEnum {
                 Ok(())
             })?
             .generate_fn("decode")
-            .with_generic_deps("__D", [format!("{}::de::Decoder<Ctx = {}>", crate_name, decode_context)])
+            .with_generic_deps("__D", [format!("{}::de::Decoder<Context = {}>", crate_name, decode_context)])
             .with_arg("decoder", "&mut __D")
             .with_return_type(format!("core::result::Result<Self, {}::error::DecodeError>", crate_name))
             .body(|fn_builder| {
@@ -261,7 +260,7 @@ impl DeriveEnum {
                 } else {
                     fn_builder
                         .push_parsed(format!(
-                            "let variant_index = <u32 as {}::Decode::<__D::Ctx>>::decode(decoder)?;",
+                            "let variant_index = <u32 as {}::Decode::<__D::Context>>::decode(decoder)?;",
                             crate_name
                         ))?;
                     fn_builder.push_parsed("match variant_index")?;
@@ -298,13 +297,13 @@ impl DeriveEnum {
                                             if attributes.with_serde {
                                                 variant_body
                                                     .push_parsed(format!(
-                                                        "<{0}::serde::Compat<_> as {0}::Decode::<__D::Ctx>>::decode(decoder)?.0,",
+                                                        "<{0}::serde::Compat<_> as {0}::Decode::<__D::Context>>::decode(decoder)?.0,",
                                                         crate_name
                                                     ))?;
                                             } else {
                                                 variant_body
                                                     .push_parsed(format!(
-                                                        "{}::Decode::<__D::Ctx>::decode(decoder)?,",
+                                                        "{}::Decode::<__D::Context>::decode(decoder)?,",
                                                         crate_name
                                                     ))?;
                                             }
@@ -362,7 +361,7 @@ impl DeriveEnum {
                 Ok(())
             })?
             .generate_fn("borrow_decode")
-            .with_generic_deps("__D", [format!("{}::de::BorrowDecoder<'__de, Ctx = {}>", crate_name, decode_context)])
+            .with_generic_deps("__D", [format!("{}::de::BorrowDecoder<'__de, Context = {}>", crate_name, decode_context)])
             .with_arg("decoder", "&mut __D")
             .with_return_type(format!("core::result::Result<Self, {}::error::DecodeError>", crate_name))
             .body(|fn_builder| {
@@ -373,7 +372,7 @@ impl DeriveEnum {
                     ))?;
                 } else {
                     fn_builder
-                        .push_parsed(format!("let variant_index = <u32 as {}::Decode::<__D::Ctx>>::decode(decoder)?;", crate_name))?;
+                        .push_parsed(format!("let variant_index = <u32 as {}::Decode::<__D::Context>>::decode(decoder)?;", crate_name))?;
                     fn_builder.push_parsed("match variant_index")?;
                     fn_builder.group(Delimiter::Brace, |variant_case| {
                         for (mut variant_index, variant) in self.iter_fields() {
@@ -407,9 +406,9 @@ impl DeriveEnum {
                                             let attributes = field.attributes().get_attribute::<FieldAttributes>()?.unwrap_or_default();
                                             if attributes.with_serde {
                                                 variant_body
-                                                    .push_parsed(format!("<{0}::serde::BorrowCompat<_> as {0}::BorrowDecode::<__D::Ctx>>::borrow_decode(decoder)?.0,", crate_name))?;
+                                                    .push_parsed(format!("<{0}::serde::BorrowCompat<_> as {0}::BorrowDecode::<__D::Context>>::borrow_decode(decoder)?.0,", crate_name))?;
                                             } else {
-                                                variant_body.push_parsed(format!("{}::BorrowDecode::<__D::Ctx>::borrow_decode(decoder)?,", crate_name))?;
+                                                variant_body.push_parsed(format!("{}::BorrowDecode::<__D::Context>::borrow_decode(decoder)?,", crate_name))?;
                                             }
                                         }
                                     }

--- a/derive/src/derive_struct.rs
+++ b/derive/src/derive_struct.rs
@@ -68,12 +68,12 @@ impl DeriveStruct {
         let decode_context = if let Some((decode_context, _)) = &self.attributes.decode_context {
             decode_context.as_str()
         } else {
-            "__Ctx"
+            "__Context"
         };
 
         let mut impl_for = generator.impl_for(format!("{}::Decode", crate_name));
         if self.attributes.decode_context.is_none() {
-            impl_for = impl_for.with_impl_generics(["__Ctx"]);
+            impl_for = impl_for.with_impl_generics(["__Context"]);
         }
 
         impl_for
@@ -143,13 +143,13 @@ impl DeriveStruct {
         let decode_context = if let Some((decode_context, _)) = &self.attributes.decode_context {
             decode_context.as_str()
         } else {
-            "__Ctx"
+            "__Context"
         };
 
         let mut impl_for =
             generator.impl_for_with_lifetimes(format!("{}::BorrowDecode", crate_name), ["__de"]).with_trait_generics([decode_context]);
         if self.attributes.decode_context.is_none() {
-            impl_for = impl_for.with_impl_generics(["__Ctx"]);
+            impl_for = impl_for.with_impl_generics(["__Context"]);
         }
 
         impl_for

--- a/derive/src/derive_struct.rs
+++ b/derive/src/derive_struct.rs
@@ -90,7 +90,7 @@ impl DeriveStruct {
                 Ok(())
             })?
             .generate_fn("decode")
-            .with_generic_deps("__D", [format!("{}::de::Decoder<Ctx = {}>", crate_name, decode_context)])
+            .with_generic_deps("__D", [format!("{}::de::Decoder<Context = {}>", crate_name, decode_context)])
             .with_arg("decoder", "&mut __D")
             .with_return_type(format!("core::result::Result<Self, {}::error::DecodeError>", crate_name))
             .body(|fn_body| {
@@ -169,7 +169,7 @@ impl DeriveStruct {
                 Ok(())
             })?
             .generate_fn("borrow_decode")
-            .with_generic_deps("__D", [format!("{}::de::BorrowDecoder<'__de, Ctx = {}>", crate_name, decode_context)])
+            .with_generic_deps("__D", [format!("{}::de::BorrowDecoder<'__de, Context = {}>", crate_name, decode_context)])
             .with_arg("decoder", "&mut __D")
             .with_return_type(format!("core::result::Result<Self, {}::error::DecodeError>", crate_name))
             .body(|fn_body| {

--- a/derive/src/derive_struct.rs
+++ b/derive/src/derive_struct.rs
@@ -1,6 +1,4 @@
 use crate::attribute::{ContainerAttributes, FieldAttributes};
-use virtue::generate::Generator;
-use virtue::parse::Fields;
 use virtue::prelude::*;
 
 pub(crate) struct DeriveStruct {

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -27,7 +27,7 @@ impl Encode for AtomicBool {
 }
 
 #[cfg(target_has_atomic = "8")]
-impl<C> Decode<C> for AtomicBool {
+impl<Context> Decode<Context> for AtomicBool {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicBool::new(Decode::decode(decoder)?))
     }
@@ -46,7 +46,7 @@ impl Encode for AtomicU8 {
 }
 
 #[cfg(target_has_atomic = "8")]
-impl<C> Decode<C> for AtomicU8 {
+impl<Context> Decode<Context> for AtomicU8 {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicU8::new(Decode::decode(decoder)?))
     }
@@ -65,7 +65,7 @@ impl Encode for AtomicU16 {
 }
 
 #[cfg(target_has_atomic = "16")]
-impl<C> Decode<C> for AtomicU16 {
+impl<Context> Decode<Context> for AtomicU16 {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicU16::new(Decode::decode(decoder)?))
     }
@@ -84,7 +84,7 @@ impl Encode for AtomicU32 {
 }
 
 #[cfg(target_has_atomic = "32")]
-impl<C> Decode<C> for AtomicU32 {
+impl<Context> Decode<Context> for AtomicU32 {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicU32::new(Decode::decode(decoder)?))
     }
@@ -103,7 +103,7 @@ impl Encode for AtomicU64 {
 }
 
 #[cfg(target_has_atomic = "64")]
-impl<C> Decode<C> for AtomicU64 {
+impl<Context> Decode<Context> for AtomicU64 {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicU64::new(Decode::decode(decoder)?))
     }
@@ -122,7 +122,7 @@ impl Encode for AtomicUsize {
 }
 
 #[cfg(target_has_atomic = "ptr")]
-impl<C> Decode<C> for AtomicUsize {
+impl<Context> Decode<Context> for AtomicUsize {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicUsize::new(Decode::decode(decoder)?))
     }
@@ -141,7 +141,7 @@ impl Encode for AtomicI8 {
 }
 
 #[cfg(target_has_atomic = "8")]
-impl<C> Decode<C> for AtomicI8 {
+impl<Context> Decode<Context> for AtomicI8 {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicI8::new(Decode::decode(decoder)?))
     }
@@ -160,7 +160,7 @@ impl Encode for AtomicI16 {
 }
 
 #[cfg(target_has_atomic = "16")]
-impl<C> Decode<C> for AtomicI16 {
+impl<Context> Decode<Context> for AtomicI16 {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicI16::new(Decode::decode(decoder)?))
     }
@@ -179,7 +179,7 @@ impl Encode for AtomicI32 {
 }
 
 #[cfg(target_has_atomic = "32")]
-impl<C> Decode<C> for AtomicI32 {
+impl<Context> Decode<Context> for AtomicI32 {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicI32::new(Decode::decode(decoder)?))
     }
@@ -198,7 +198,7 @@ impl Encode for AtomicI64 {
 }
 
 #[cfg(target_has_atomic = "64")]
-impl<C> Decode<C> for AtomicI64 {
+impl<Context> Decode<Context> for AtomicI64 {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicI64::new(Decode::decode(decoder)?))
     }
@@ -217,7 +217,7 @@ impl Encode for AtomicIsize {
 }
 
 #[cfg(target_has_atomic = "ptr")]
-impl<C> Decode<C> for AtomicIsize {
+impl<Context> Decode<Context> for AtomicIsize {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicIsize::new(Decode::decode(decoder)?))
     }

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -27,7 +27,7 @@ impl Encode for AtomicBool {
 }
 
 #[cfg(target_has_atomic = "8")]
-impl Decode for AtomicBool {
+impl<C> Decode<C> for AtomicBool {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicBool::new(Decode::decode(decoder)?))
     }
@@ -46,7 +46,7 @@ impl Encode for AtomicU8 {
 }
 
 #[cfg(target_has_atomic = "8")]
-impl Decode for AtomicU8 {
+impl<C> Decode<C> for AtomicU8 {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicU8::new(Decode::decode(decoder)?))
     }
@@ -65,7 +65,7 @@ impl Encode for AtomicU16 {
 }
 
 #[cfg(target_has_atomic = "16")]
-impl Decode for AtomicU16 {
+impl<C> Decode<C> for AtomicU16 {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicU16::new(Decode::decode(decoder)?))
     }
@@ -84,7 +84,7 @@ impl Encode for AtomicU32 {
 }
 
 #[cfg(target_has_atomic = "32")]
-impl Decode for AtomicU32 {
+impl<C> Decode<C> for AtomicU32 {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicU32::new(Decode::decode(decoder)?))
     }
@@ -103,7 +103,7 @@ impl Encode for AtomicU64 {
 }
 
 #[cfg(target_has_atomic = "64")]
-impl Decode for AtomicU64 {
+impl<C> Decode<C> for AtomicU64 {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicU64::new(Decode::decode(decoder)?))
     }
@@ -122,7 +122,7 @@ impl Encode for AtomicUsize {
 }
 
 #[cfg(target_has_atomic = "ptr")]
-impl Decode for AtomicUsize {
+impl<C> Decode<C> for AtomicUsize {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicUsize::new(Decode::decode(decoder)?))
     }
@@ -141,7 +141,7 @@ impl Encode for AtomicI8 {
 }
 
 #[cfg(target_has_atomic = "8")]
-impl Decode for AtomicI8 {
+impl<C> Decode<C> for AtomicI8 {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicI8::new(Decode::decode(decoder)?))
     }
@@ -160,7 +160,7 @@ impl Encode for AtomicI16 {
 }
 
 #[cfg(target_has_atomic = "16")]
-impl Decode for AtomicI16 {
+impl<C> Decode<C> for AtomicI16 {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicI16::new(Decode::decode(decoder)?))
     }
@@ -179,7 +179,7 @@ impl Encode for AtomicI32 {
 }
 
 #[cfg(target_has_atomic = "32")]
-impl Decode for AtomicI32 {
+impl<C> Decode<C> for AtomicI32 {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicI32::new(Decode::decode(decoder)?))
     }
@@ -198,7 +198,7 @@ impl Encode for AtomicI64 {
 }
 
 #[cfg(target_has_atomic = "64")]
-impl Decode for AtomicI64 {
+impl<C> Decode<C> for AtomicI64 {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicI64::new(Decode::decode(decoder)?))
     }
@@ -217,7 +217,7 @@ impl Encode for AtomicIsize {
 }
 
 #[cfg(target_has_atomic = "ptr")]
-impl Decode for AtomicIsize {
+impl<C> Decode<C> for AtomicIsize {
     fn decode<D: crate::de::Decoder>(decoder: &mut D) -> Result<Self, crate::error::DecodeError> {
         Ok(AtomicIsize::new(Decode::decode(decoder)?))
     }

--- a/src/de/decoder.rs
+++ b/src/de/decoder.rs
@@ -20,28 +20,30 @@ use crate::{config::Config, error::DecodeError, utils::Sealed};
 /// // this u32 can be any Decode
 /// let value = u32::decode(&mut decoder).unwrap();
 /// ```
-pub struct DecoderImpl<R, C: Config, Ctx> {
+pub struct DecoderImpl<R, C: Config, Context> {
     reader: R,
     config: C,
     bytes_read: usize,
-    ctx: Ctx,
+    context: Context,
 }
 
-impl<R: Reader, C: Config, Ctx> DecoderImpl<R, C, Ctx> {
+impl<R: Reader, C: Config, Context> DecoderImpl<R, C, Context> {
     /// Construct a new Decoder
-    pub const fn new(reader: R, config: C, ctx: Ctx) -> DecoderImpl<R, C, Ctx> {
+    pub const fn new(reader: R, config: C, context: Context) -> DecoderImpl<R, C, Context> {
         DecoderImpl {
             reader,
             config,
             bytes_read: 0,
-            ctx,
+            context,
         }
     }
 }
 
-impl<R, C: Config, Ctx> Sealed for DecoderImpl<R, C, Ctx> {}
+impl<R, C: Config, Context> Sealed for DecoderImpl<R, C, Context> {}
 
-impl<'de, R: BorrowReader<'de>, C: Config, Ctx> BorrowDecoder<'de> for DecoderImpl<R, C, Ctx> {
+impl<'de, R: BorrowReader<'de>, C: Config, Context> BorrowDecoder<'de>
+    for DecoderImpl<R, C, Context>
+{
     type BR = R;
 
     fn borrow_reader(&mut self) -> &mut Self::BR {
@@ -49,11 +51,11 @@ impl<'de, R: BorrowReader<'de>, C: Config, Ctx> BorrowDecoder<'de> for DecoderIm
     }
 }
 
-impl<R: Reader, C: Config, Ctx> Decoder for DecoderImpl<R, C, Ctx> {
+impl<R: Reader, C: Config, Context> Decoder for DecoderImpl<R, C, Context> {
     type R = R;
 
     type C = C;
-    type Ctx = Ctx;
+    type Context = Context;
 
     fn reader(&mut self) -> &mut Self::R {
         &mut self.reader
@@ -91,27 +93,27 @@ impl<R: Reader, C: Config, Ctx> Decoder for DecoderImpl<R, C, Ctx> {
         }
     }
 
-    fn ctx(&mut self) -> &mut Self::Ctx {
-        &mut self.ctx
+    fn context(&mut self) -> &mut Self::Context {
+        &mut self.context
     }
 }
 
 pub struct WithContext<'a, D: ?Sized, C> {
     pub(crate) decoder: &'a mut D,
-    pub(crate) ctx: &'a mut C,
+    pub(crate) context: &'a mut C,
 }
 
 impl<'a, C, D: Decoder + ?Sized> Sealed for WithContext<'a, D, C> {}
 
-impl<'a, Ctx, D: Decoder + ?Sized> Decoder for WithContext<'a, D, Ctx> {
+impl<'a, Context, D: Decoder + ?Sized> Decoder for WithContext<'a, D, Context> {
     type R = D::R;
 
     type C = D::C;
 
-    type Ctx = Ctx;
+    type Context = Context;
 
-    fn ctx(&mut self) -> &mut Self::Ctx {
-        &mut self.ctx
+    fn context(&mut self) -> &mut Self::Context {
+        &mut self.context
     }
 
     fn reader(&mut self) -> &mut Self::R {

--- a/src/de/decoder.rs
+++ b/src/de/decoder.rs
@@ -20,16 +20,16 @@ use crate::{config::Config, error::DecodeError, utils::Sealed};
 /// // this u32 can be any Decode
 /// let value = u32::decode(&mut decoder).unwrap();
 /// ```
-pub struct DecoderImpl<R, C: Config, Context> {
+pub struct DecoderImpl<'context, R, C: Config, Context> {
     reader: R,
     config: C,
     bytes_read: usize,
-    context: Context,
+    context: &'context mut Context,
 }
 
-impl<R: Reader, C: Config, Context> DecoderImpl<R, C, Context> {
+impl<'context, R: Reader, C: Config, Context> DecoderImpl<'context, R, C, Context> {
     /// Construct a new Decoder
-    pub const fn new(reader: R, config: C, context: Context) -> DecoderImpl<R, C, Context> {
+    pub fn new(reader: R, config: C, context: &'context mut Context) -> DecoderImpl<'context, R, C, Context> {
         DecoderImpl {
             reader,
             config,
@@ -39,10 +39,10 @@ impl<R: Reader, C: Config, Context> DecoderImpl<R, C, Context> {
     }
 }
 
-impl<R, C: Config, Context> Sealed for DecoderImpl<R, C, Context> {}
+impl<'context, R, C: Config, Context> Sealed for DecoderImpl<'context, R, C, Context> {}
 
-impl<'de, R: BorrowReader<'de>, C: Config, Context> BorrowDecoder<'de>
-    for DecoderImpl<R, C, Context>
+impl<'context, 'de, R: BorrowReader<'de>, C: Config, Context> BorrowDecoder<'de>
+    for DecoderImpl<'context, R, C, Context>
 {
     type BR = R;
 
@@ -51,7 +51,7 @@ impl<'de, R: BorrowReader<'de>, C: Config, Context> BorrowDecoder<'de>
     }
 }
 
-impl<R: Reader, C: Config, Context> Decoder for DecoderImpl<R, C, Context> {
+impl<'context, R: Reader, C: Config, Context> Decoder for DecoderImpl<'context, R, C, Context> {
     type R = R;
 
     type C = C;
@@ -94,7 +94,7 @@ impl<R: Reader, C: Config, Context> Decoder for DecoderImpl<R, C, Context> {
     }
 
     fn context(&mut self) -> &mut Self::Context {
-        &mut self.context
+        self.context
     }
 }
 

--- a/src/de/decoder.rs
+++ b/src/de/decoder.rs
@@ -20,26 +20,28 @@ use crate::{config::Config, error::DecodeError, utils::Sealed};
 /// // this u32 can be any Decode
 /// let value = u32::decode(&mut decoder).unwrap();
 /// ```
-pub struct DecoderImpl<R, C: Config> {
+pub struct DecoderImpl<R, C: Config, Ctx> {
     reader: R,
     config: C,
     bytes_read: usize,
+    ctx: Ctx,
 }
 
-impl<R: Reader, C: Config> DecoderImpl<R, C> {
+impl<R: Reader, C: Config, Ctx> DecoderImpl<R, C, Ctx> {
     /// Construct a new Decoder
-    pub const fn new(reader: R, config: C) -> DecoderImpl<R, C> {
+    pub const fn new(reader: R, config: C, ctx: Ctx) -> DecoderImpl<R, C, Ctx> {
         DecoderImpl {
             reader,
             config,
             bytes_read: 0,
+            ctx,
         }
     }
 }
 
-impl<R, C: Config> Sealed for DecoderImpl<R, C> {}
+impl<R, C: Config, Ctx> Sealed for DecoderImpl<R, C, Ctx> {}
 
-impl<'de, R: BorrowReader<'de>, C: Config> BorrowDecoder<'de> for DecoderImpl<R, C> {
+impl<'de, R: BorrowReader<'de>, C: Config, Ctx> BorrowDecoder<'de> for DecoderImpl<R, C, Ctx> {
     type BR = R;
 
     fn borrow_reader(&mut self) -> &mut Self::BR {
@@ -47,10 +49,11 @@ impl<'de, R: BorrowReader<'de>, C: Config> BorrowDecoder<'de> for DecoderImpl<R,
     }
 }
 
-impl<R: Reader, C: Config> Decoder for DecoderImpl<R, C> {
+impl<R: Reader, C: Config, Ctx> Decoder for DecoderImpl<R, C, Ctx> {
     type R = R;
 
     type C = C;
+    type Ctx = Ctx;
 
     fn reader(&mut self) -> &mut Self::R {
         &mut self.reader

--- a/src/de/decoder.rs
+++ b/src/de/decoder.rs
@@ -16,7 +16,7 @@ use crate::{config::Config, error::DecodeError, utils::Sealed};
 /// # let slice: &[u8] = &[0, 0, 0, 0];
 /// # let some_reader = bincode::de::read::SliceReader::new(slice);
 /// use bincode::de::{DecoderImpl, Decode};
-/// let mut decoder = DecoderImpl::new(some_reader, bincode::config::standard());
+/// let mut decoder = DecoderImpl::new(some_reader, bincode::config::standard(), ());
 /// // this u32 can be any Decode
 /// let value = u32::decode(&mut decoder).unwrap();
 /// ```
@@ -89,5 +89,9 @@ impl<R: Reader, C: Config, Ctx> Decoder for DecoderImpl<R, C, Ctx> {
             // We should always be claiming more than we unclaim, so this should never underflow
             self.bytes_read -= n;
         }
+    }
+
+    fn ctx(&mut self) -> &mut Self::Ctx {
+        &mut self.ctx
     }
 }

--- a/src/de/impl_tuples.rs
+++ b/src/de/impl_tuples.rs
@@ -4,14 +4,14 @@ use crate::error::DecodeError;
 macro_rules! impl_tuple {
     () => {};
     ($first:ident $(, $extra:ident)*) => {
-        impl<'de, $first $(, $extra)*> BorrowDecode<'de> for ($first, $($extra, )*)
+        impl<'de, $first $(, $extra)*, Ctx> BorrowDecode<'de, Ctx> for ($first, $($extra, )*)
         where
-            $first: BorrowDecode<'de>,
+            $first: BorrowDecode<'de, Ctx>,
         $(
-            $extra : BorrowDecode<'de>,
+            $extra : BorrowDecode<'de, Ctx>,
         )*
          {
-            fn borrow_decode<BD: BorrowDecoder<'de>>(decoder: &mut BD) -> Result<Self, DecodeError> {
+            fn borrow_decode<BD: BorrowDecoder<'de, Ctx = Ctx>>(decoder: &mut BD) -> Result<Self, DecodeError> {
                 Ok((
                     $first::borrow_decode(decoder)?,
                     $($extra :: borrow_decode(decoder)?, )*
@@ -26,7 +26,7 @@ macro_rules! impl_tuple {
             $extra : Decode<Ctx>,
         )*
         {
-            fn decode<DE: Decoder<Ctx=Ctx>>(decoder: &mut DE) -> Result<Self, DecodeError> {
+            fn decode<DE: Decoder<Ctx = Ctx>>(decoder: &mut DE) -> Result<Self, DecodeError> {
                 Ok((
                     $first::decode(decoder)?,
                     $($extra :: decode(decoder)?, )*

--- a/src/de/impl_tuples.rs
+++ b/src/de/impl_tuples.rs
@@ -4,14 +4,14 @@ use crate::error::DecodeError;
 macro_rules! impl_tuple {
     () => {};
     ($first:ident $(, $extra:ident)*) => {
-        impl<'de, $first $(, $extra)*, Ctx> BorrowDecode<'de, Ctx> for ($first, $($extra, )*)
+        impl<'de, $first $(, $extra)*, Context> BorrowDecode<'de, Context> for ($first, $($extra, )*)
         where
-            $first: BorrowDecode<'de, Ctx>,
+            $first: BorrowDecode<'de, Context>,
         $(
-            $extra : BorrowDecode<'de, Ctx>,
+            $extra : BorrowDecode<'de, Context>,
         )*
          {
-            fn borrow_decode<BD: BorrowDecoder<'de, Ctx = Ctx>>(decoder: &mut BD) -> Result<Self, DecodeError> {
+            fn borrow_decode<BD: BorrowDecoder<'de, Context = Context>>(decoder: &mut BD) -> Result<Self, DecodeError> {
                 Ok((
                     $first::borrow_decode(decoder)?,
                     $($extra :: borrow_decode(decoder)?, )*
@@ -19,14 +19,14 @@ macro_rules! impl_tuple {
             }
         }
 
-        impl<Ctx, $first $(, $extra)*> Decode<Ctx> for ($first, $($extra, )*)
+        impl<Context, $first $(, $extra)*> Decode<Context> for ($first, $($extra, )*)
         where
-            $first: Decode<Ctx>,
+            $first: Decode<Context>,
         $(
-            $extra : Decode<Ctx>,
+            $extra : Decode<Context>,
         )*
         {
-            fn decode<DE: Decoder<Ctx = Ctx>>(decoder: &mut DE) -> Result<Self, DecodeError> {
+            fn decode<DE: Decoder<Context = Context>>(decoder: &mut DE) -> Result<Self, DecodeError> {
                 Ok((
                     $first::decode(decoder)?,
                     $($extra :: decode(decoder)?, )*

--- a/src/de/impl_tuples.rs
+++ b/src/de/impl_tuples.rs
@@ -19,14 +19,14 @@ macro_rules! impl_tuple {
             }
         }
 
-        impl<$first $(, $extra)*> Decode for ($first, $($extra, )*)
+        impl<Ctx, $first $(, $extra)*> Decode<Ctx> for ($first, $($extra, )*)
         where
-            $first: Decode,
+            $first: Decode<Ctx>,
         $(
-            $extra : Decode,
+            $extra : Decode<Ctx>,
         )*
         {
-            fn decode<DE: Decoder>(decoder: &mut DE) -> Result<Self, DecodeError> {
+            fn decode<DE: Decoder<Ctx=Ctx>>(decoder: &mut DE) -> Result<Self, DecodeError> {
                 Ok((
                     $first::decode(decoder)?,
                     $($extra :: decode(decoder)?, )*

--- a/src/de/impls.rs
+++ b/src/de/impls.rs
@@ -19,7 +19,7 @@ use core::{
 };
 
 impl<C> Decode<C> for bool {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         match u8::decode(decoder)? {
             0 => Ok(false),
             1 => Ok(true),
@@ -31,7 +31,7 @@ impl_borrow_decode!(bool);
 
 impl<C> Decode<C> for u8 {
     #[inline]
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(1)?;
         if let Some(buf) = decoder.reader().peek_read(1) {
             let byte = buf[0];
@@ -47,7 +47,7 @@ impl<C> Decode<C> for u8 {
 impl_borrow_decode!(u8);
 
 impl<C> Decode<C> for NonZeroU8 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroU8::new(u8::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::U8,
         })
@@ -56,7 +56,7 @@ impl<C> Decode<C> for NonZeroU8 {
 impl_borrow_decode!(NonZeroU8);
 
 impl<C> Decode<C> for u16 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(2)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -76,7 +76,7 @@ impl<C> Decode<C> for u16 {
 impl_borrow_decode!(u16);
 
 impl<C> Decode<C> for NonZeroU16 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroU16::new(u16::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::U16,
         })
@@ -85,7 +85,7 @@ impl<C> Decode<C> for NonZeroU16 {
 impl_borrow_decode!(NonZeroU16);
 
 impl<C> Decode<C> for u32 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(4)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -105,7 +105,7 @@ impl<C> Decode<C> for u32 {
 impl_borrow_decode!(u32);
 
 impl<C> Decode<C> for NonZeroU32 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroU32::new(u32::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::U32,
         })
@@ -114,7 +114,7 @@ impl<C> Decode<C> for NonZeroU32 {
 impl_borrow_decode!(NonZeroU32);
 
 impl<C> Decode<C> for u64 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(8)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -134,7 +134,7 @@ impl<C> Decode<C> for u64 {
 impl_borrow_decode!(u64);
 
 impl<C> Decode<C> for NonZeroU64 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroU64::new(u64::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::U64,
         })
@@ -143,7 +143,7 @@ impl<C> Decode<C> for NonZeroU64 {
 impl_borrow_decode!(NonZeroU64);
 
 impl<C> Decode<C> for u128 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(16)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -163,7 +163,7 @@ impl<C> Decode<C> for u128 {
 impl_borrow_decode!(u128);
 
 impl<C> Decode<C> for NonZeroU128 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroU128::new(u128::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::U128,
         })
@@ -172,7 +172,7 @@ impl<C> Decode<C> for NonZeroU128 {
 impl_borrow_decode!(NonZeroU128);
 
 impl<C> Decode<C> for usize {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(8)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -197,7 +197,7 @@ impl<C> Decode<C> for usize {
 impl_borrow_decode!(usize);
 
 impl<C> Decode<C> for NonZeroUsize {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroUsize::new(usize::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::Usize,
         })
@@ -206,7 +206,7 @@ impl<C> Decode<C> for NonZeroUsize {
 impl_borrow_decode!(NonZeroUsize);
 
 impl<C> Decode<C> for i8 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(1)?;
         let mut bytes = [0u8; 1];
         decoder.reader().read(&mut bytes)?;
@@ -216,7 +216,7 @@ impl<C> Decode<C> for i8 {
 impl_borrow_decode!(i8);
 
 impl<C> Decode<C> for NonZeroI8 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroI8::new(i8::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::I8,
         })
@@ -225,7 +225,7 @@ impl<C> Decode<C> for NonZeroI8 {
 impl_borrow_decode!(NonZeroI8);
 
 impl<C> Decode<C> for i16 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(2)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -245,7 +245,7 @@ impl<C> Decode<C> for i16 {
 impl_borrow_decode!(i16);
 
 impl<C> Decode<C> for NonZeroI16 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroI16::new(i16::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::I16,
         })
@@ -254,7 +254,7 @@ impl<C> Decode<C> for NonZeroI16 {
 impl_borrow_decode!(NonZeroI16);
 
 impl<C> Decode<C> for i32 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(4)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -274,7 +274,7 @@ impl<C> Decode<C> for i32 {
 impl_borrow_decode!(i32);
 
 impl<C> Decode<C> for NonZeroI32 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroI32::new(i32::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::I32,
         })
@@ -283,7 +283,7 @@ impl<C> Decode<C> for NonZeroI32 {
 impl_borrow_decode!(NonZeroI32);
 
 impl<C> Decode<C> for i64 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(8)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -303,7 +303,7 @@ impl<C> Decode<C> for i64 {
 impl_borrow_decode!(i64);
 
 impl<C> Decode<C> for NonZeroI64 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroI64::new(i64::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::I64,
         })
@@ -312,7 +312,7 @@ impl<C> Decode<C> for NonZeroI64 {
 impl_borrow_decode!(NonZeroI64);
 
 impl<C> Decode<C> for i128 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(16)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -332,7 +332,7 @@ impl<C> Decode<C> for i128 {
 impl_borrow_decode!(i128);
 
 impl<C> Decode<C> for NonZeroI128 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroI128::new(i128::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::I128,
         })
@@ -341,7 +341,7 @@ impl<C> Decode<C> for NonZeroI128 {
 impl_borrow_decode!(NonZeroI128);
 
 impl<C> Decode<C> for isize {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(8)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -361,7 +361,7 @@ impl<C> Decode<C> for isize {
 impl_borrow_decode!(isize);
 
 impl<C> Decode<C> for NonZeroIsize {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroIsize::new(isize::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::Isize,
         })
@@ -370,7 +370,7 @@ impl<C> Decode<C> for NonZeroIsize {
 impl_borrow_decode!(NonZeroIsize);
 
 impl<C> Decode<C> for f32 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(4)?;
         let mut bytes = [0u8; 4];
         decoder.reader().read(&mut bytes)?;
@@ -383,7 +383,7 @@ impl<C> Decode<C> for f32 {
 impl_borrow_decode!(f32);
 
 impl<C> Decode<C> for f64 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(8)?;
         let mut bytes = [0u8; 8];
         decoder.reader().read(&mut bytes)?;
@@ -396,12 +396,12 @@ impl<C> Decode<C> for f64 {
 impl_borrow_decode!(f64);
 
 impl<C, T: Decode<C>> Decode<C> for Wrapping<T> {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         Ok(Wrapping(T::decode(decoder)?))
     }
 }
-impl<'de, Ctx, T: BorrowDecode<'de, Ctx>> BorrowDecode<'de, Ctx> for Wrapping<T> {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+impl<'de, Context, T: BorrowDecode<'de, Context>> BorrowDecode<'de, Context> for Wrapping<T> {
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         Ok(Wrapping(T::borrow_decode(decoder)?))
@@ -409,13 +409,13 @@ impl<'de, Ctx, T: BorrowDecode<'de, Ctx>> BorrowDecode<'de, Ctx> for Wrapping<T>
 }
 
 impl<C, T: Decode<C>> Decode<C> for Reverse<T> {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         Ok(Reverse(T::decode(decoder)?))
     }
 }
 
-impl<'de, Ctx, T: BorrowDecode<'de, Ctx>> BorrowDecode<'de, Ctx> for Reverse<T> {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+impl<'de, Context, T: BorrowDecode<'de, Context>> BorrowDecode<'de, Context> for Reverse<T> {
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         Ok(Reverse(T::borrow_decode(decoder)?))
@@ -423,7 +423,7 @@ impl<'de, Ctx, T: BorrowDecode<'de, Ctx>> BorrowDecode<'de, Ctx> for Reverse<T> 
 }
 
 impl<C> Decode<C> for char {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let mut array = [0u8; 4];
 
         // Look at the first byte to see how many bytes must be read
@@ -452,8 +452,8 @@ impl<C> Decode<C> for char {
 }
 impl_borrow_decode!(char);
 
-impl<'a, 'de: 'a, Ctx> BorrowDecode<'de, Ctx> for &'a [u8] {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+impl<'a, 'de: 'a, Context> BorrowDecode<'de, Context> for &'a [u8] {
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         let len = super::decode_slice_len(decoder)?;
@@ -462,8 +462,8 @@ impl<'a, 'de: 'a, Ctx> BorrowDecode<'de, Ctx> for &'a [u8] {
     }
 }
 
-impl<'a, 'de: 'a, Ctx> BorrowDecode<'de, Ctx> for &'a str {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+impl<'a, 'de: 'a, Context> BorrowDecode<'de, Context> for &'a str {
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         let slice = <&[u8]>::borrow_decode(decoder)?;
@@ -475,7 +475,7 @@ impl<C, T, const N: usize> Decode<C> for [T; N]
 where
     T: Decode<C>,
 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(core::mem::size_of::<[T; N]>())?;
 
         if unty::type_equal::<T, u8>() {
@@ -501,11 +501,11 @@ where
     }
 }
 
-impl<'de, T, const N: usize, Ctx> BorrowDecode<'de, Ctx> for [T; N]
+impl<'de, T, const N: usize, Context> BorrowDecode<'de, Context> for [T; N]
 where
-    T: BorrowDecode<'de, Ctx>,
+    T: BorrowDecode<'de, Context>,
 {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(core::mem::size_of::<[T; N]>())?;
@@ -534,14 +534,14 @@ where
 }
 
 impl<C> Decode<C> for () {
-    fn decode<D: Decoder<Ctx = C>>(_: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(_: &mut D) -> Result<Self, DecodeError> {
         Ok(())
     }
 }
 impl_borrow_decode!(());
 
 impl<C, T> Decode<C> for core::marker::PhantomData<T> {
-    fn decode<D: Decoder<Ctx = C>>(_: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(_: &mut D) -> Result<Self, DecodeError> {
         Ok(core::marker::PhantomData)
     }
 }
@@ -551,7 +551,7 @@ impl<C, T> Decode<C> for Option<T>
 where
     T: Decode<C>,
 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         match super::decode_option_variant(decoder, core::any::type_name::<Option<T>>())? {
             Some(_) => {
                 let val = T::decode(decoder)?;
@@ -562,11 +562,11 @@ where
     }
 }
 
-impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for Option<T>
+impl<'de, T, Context> BorrowDecode<'de, Context> for Option<T>
 where
-    T: BorrowDecode<'de, Ctx>,
+    T: BorrowDecode<'de, Context>,
 {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         match super::decode_option_variant(decoder, core::any::type_name::<Option<T>>())? {
@@ -584,7 +584,7 @@ where
     T: Decode<C>,
     U: Decode<C>,
 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let is_ok = u32::decode(decoder)?;
         match is_ok {
             0 => {
@@ -604,12 +604,12 @@ where
     }
 }
 
-impl<'de, T, U, Ctx> BorrowDecode<'de, Ctx> for Result<T, U>
+impl<'de, T, U, Context> BorrowDecode<'de, Context> for Result<T, U>
 where
-    T: BorrowDecode<'de, Ctx>,
-    U: BorrowDecode<'de, Ctx>,
+    T: BorrowDecode<'de, Context>,
+    U: BorrowDecode<'de, Context>,
 {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         let is_ok = u32::decode(decoder)?;
@@ -635,17 +635,17 @@ impl<C, T> Decode<C> for Cell<T>
 where
     T: Decode<C>,
 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let t = T::decode(decoder)?;
         Ok(Cell::new(t))
     }
 }
 
-impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for Cell<T>
+impl<'de, T, Context> BorrowDecode<'de, Context> for Cell<T>
 where
-    T: BorrowDecode<'de, Ctx>,
+    T: BorrowDecode<'de, Context>,
 {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         let t = T::borrow_decode(decoder)?;
@@ -657,17 +657,17 @@ impl<C, T> Decode<C> for RefCell<T>
 where
     T: Decode<C>,
 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let t = T::decode(decoder)?;
         Ok(RefCell::new(t))
     }
 }
 
-impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for RefCell<T>
+impl<'de, T, Context> BorrowDecode<'de, Context> for RefCell<T>
 where
-    T: BorrowDecode<'de, Ctx>,
+    T: BorrowDecode<'de, Context>,
 {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         let t = T::borrow_decode(decoder)?;
@@ -676,7 +676,7 @@ where
 }
 
 impl<C> Decode<C> for Duration {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         const NANOS_PER_SEC: u64 = 1_000_000_000;
         let secs: u64 = Decode::decode(decoder)?;
         let nanos: u32 = Decode::decode(decoder)?;
@@ -692,17 +692,17 @@ impl<C, T> Decode<C> for Range<T>
 where
     T: Decode<C>,
 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let min = T::decode(decoder)?;
         let max = T::decode(decoder)?;
         Ok(min..max)
     }
 }
-impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for Range<T>
+impl<'de, T, Context> BorrowDecode<'de, Context> for Range<T>
 where
-    T: BorrowDecode<'de, Ctx>,
+    T: BorrowDecode<'de, Context>,
 {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         let min = T::borrow_decode(decoder)?;
@@ -715,18 +715,18 @@ impl<C, T> Decode<C> for RangeInclusive<T>
 where
     T: Decode<C>,
 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let min = T::decode(decoder)?;
         let max = T::decode(decoder)?;
         Ok(RangeInclusive::new(min, max))
     }
 }
 
-impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for RangeInclusive<T>
+impl<'de, T, Context> BorrowDecode<'de, Context> for RangeInclusive<T>
 where
-    T: BorrowDecode<'de, Ctx>,
+    T: BorrowDecode<'de, Context>,
 {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         let min = T::borrow_decode(decoder)?;
@@ -739,7 +739,7 @@ impl<T, C> Decode<C> for Bound<T>
 where
     T: Decode<C>,
 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         match u32::decode(decoder)? {
             0 => Ok(Bound::Unbounded),
             1 => Ok(Bound::Included(T::decode(decoder)?)),
@@ -753,11 +753,11 @@ where
     }
 }
 
-impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for Bound<T>
+impl<'de, T, Context> BorrowDecode<'de, Context> for Bound<T>
 where
-    T: BorrowDecode<'de, Ctx>,
+    T: BorrowDecode<'de, Context>,
 {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         match u32::decode(decoder)? {

--- a/src/de/impls.rs
+++ b/src/de/impls.rs
@@ -18,8 +18,8 @@ use core::{
     time::Duration,
 };
 
-impl Decode for bool {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for bool {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         match u8::decode(decoder)? {
             0 => Ok(false),
             1 => Ok(true),
@@ -29,9 +29,9 @@ impl Decode for bool {
 }
 impl_borrow_decode!(bool);
 
-impl Decode for u8 {
+impl<C> Decode<C> for u8 {
     #[inline]
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(1)?;
         if let Some(buf) = decoder.reader().peek_read(1) {
             let byte = buf[0];
@@ -46,8 +46,8 @@ impl Decode for u8 {
 }
 impl_borrow_decode!(u8);
 
-impl Decode for NonZeroU8 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for NonZeroU8 {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroU8::new(u8::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::U8,
         })
@@ -55,8 +55,8 @@ impl Decode for NonZeroU8 {
 }
 impl_borrow_decode!(NonZeroU8);
 
-impl Decode for u16 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for u16 {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(2)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -75,8 +75,8 @@ impl Decode for u16 {
 }
 impl_borrow_decode!(u16);
 
-impl Decode for NonZeroU16 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for NonZeroU16 {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroU16::new(u16::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::U16,
         })
@@ -84,8 +84,8 @@ impl Decode for NonZeroU16 {
 }
 impl_borrow_decode!(NonZeroU16);
 
-impl Decode for u32 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for u32 {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(4)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -104,8 +104,8 @@ impl Decode for u32 {
 }
 impl_borrow_decode!(u32);
 
-impl Decode for NonZeroU32 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for NonZeroU32 {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroU32::new(u32::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::U32,
         })
@@ -113,8 +113,8 @@ impl Decode for NonZeroU32 {
 }
 impl_borrow_decode!(NonZeroU32);
 
-impl Decode for u64 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for u64 {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(8)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -133,8 +133,8 @@ impl Decode for u64 {
 }
 impl_borrow_decode!(u64);
 
-impl Decode for NonZeroU64 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for NonZeroU64 {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroU64::new(u64::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::U64,
         })
@@ -142,8 +142,8 @@ impl Decode for NonZeroU64 {
 }
 impl_borrow_decode!(NonZeroU64);
 
-impl Decode for u128 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for u128 {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(16)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -162,8 +162,8 @@ impl Decode for u128 {
 }
 impl_borrow_decode!(u128);
 
-impl Decode for NonZeroU128 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for NonZeroU128 {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroU128::new(u128::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::U128,
         })
@@ -171,8 +171,8 @@ impl Decode for NonZeroU128 {
 }
 impl_borrow_decode!(NonZeroU128);
 
-impl Decode for usize {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for usize {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(8)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -196,8 +196,8 @@ impl Decode for usize {
 }
 impl_borrow_decode!(usize);
 
-impl Decode for NonZeroUsize {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for NonZeroUsize {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroUsize::new(usize::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::Usize,
         })
@@ -205,8 +205,8 @@ impl Decode for NonZeroUsize {
 }
 impl_borrow_decode!(NonZeroUsize);
 
-impl Decode for i8 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for i8 {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(1)?;
         let mut bytes = [0u8; 1];
         decoder.reader().read(&mut bytes)?;
@@ -215,8 +215,8 @@ impl Decode for i8 {
 }
 impl_borrow_decode!(i8);
 
-impl Decode for NonZeroI8 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for NonZeroI8 {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroI8::new(i8::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::I8,
         })
@@ -224,8 +224,8 @@ impl Decode for NonZeroI8 {
 }
 impl_borrow_decode!(NonZeroI8);
 
-impl Decode for i16 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for i16 {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(2)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -244,8 +244,8 @@ impl Decode for i16 {
 }
 impl_borrow_decode!(i16);
 
-impl Decode for NonZeroI16 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for NonZeroI16 {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroI16::new(i16::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::I16,
         })
@@ -253,8 +253,8 @@ impl Decode for NonZeroI16 {
 }
 impl_borrow_decode!(NonZeroI16);
 
-impl Decode for i32 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for i32 {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(4)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -273,8 +273,8 @@ impl Decode for i32 {
 }
 impl_borrow_decode!(i32);
 
-impl Decode for NonZeroI32 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for NonZeroI32 {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroI32::new(i32::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::I32,
         })
@@ -282,8 +282,8 @@ impl Decode for NonZeroI32 {
 }
 impl_borrow_decode!(NonZeroI32);
 
-impl Decode for i64 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for i64 {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(8)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -302,8 +302,8 @@ impl Decode for i64 {
 }
 impl_borrow_decode!(i64);
 
-impl Decode for NonZeroI64 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for NonZeroI64 {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroI64::new(i64::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::I64,
         })
@@ -311,8 +311,8 @@ impl Decode for NonZeroI64 {
 }
 impl_borrow_decode!(NonZeroI64);
 
-impl Decode for i128 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for i128 {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(16)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -331,8 +331,8 @@ impl Decode for i128 {
 }
 impl_borrow_decode!(i128);
 
-impl Decode for NonZeroI128 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for NonZeroI128 {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroI128::new(i128::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::I128,
         })
@@ -340,8 +340,8 @@ impl Decode for NonZeroI128 {
 }
 impl_borrow_decode!(NonZeroI128);
 
-impl Decode for isize {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for isize {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(8)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -360,8 +360,8 @@ impl Decode for isize {
 }
 impl_borrow_decode!(isize);
 
-impl Decode for NonZeroIsize {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for NonZeroIsize {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroIsize::new(isize::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::Isize,
         })
@@ -369,8 +369,8 @@ impl Decode for NonZeroIsize {
 }
 impl_borrow_decode!(NonZeroIsize);
 
-impl Decode for f32 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for f32 {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(4)?;
         let mut bytes = [0u8; 4];
         decoder.reader().read(&mut bytes)?;
@@ -382,8 +382,8 @@ impl Decode for f32 {
 }
 impl_borrow_decode!(f32);
 
-impl Decode for f64 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for f64 {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(8)?;
         let mut bytes = [0u8; 8];
         decoder.reader().read(&mut bytes)?;
@@ -395,8 +395,8 @@ impl Decode for f64 {
 }
 impl_borrow_decode!(f64);
 
-impl<T: Decode> Decode for Wrapping<T> {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C, T: Decode<C>> Decode<C> for Wrapping<T> {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         Ok(Wrapping(T::decode(decoder)?))
     }
 }
@@ -406,8 +406,8 @@ impl<'de, T: BorrowDecode<'de>> BorrowDecode<'de> for Wrapping<T> {
     }
 }
 
-impl<T: Decode> Decode for Reverse<T> {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C, T: Decode<C>> Decode<C> for Reverse<T> {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         Ok(Reverse(T::decode(decoder)?))
     }
 }
@@ -418,8 +418,8 @@ impl<'de, T: BorrowDecode<'de>> BorrowDecode<'de> for Reverse<T> {
     }
 }
 
-impl Decode for char {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for char {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let mut array = [0u8; 4];
 
         // Look at the first byte to see how many bytes must be read
@@ -463,11 +463,11 @@ impl<'a, 'de: 'a> BorrowDecode<'de> for &'a str {
     }
 }
 
-impl<T, const N: usize> Decode for [T; N]
+impl<C, T, const N: usize> Decode<C> for [T; N]
 where
-    T: Decode,
+    T: Decode<C>,
 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(core::mem::size_of::<[T; N]>())?;
 
         if unty::type_equal::<T, u8>() {
@@ -523,25 +523,25 @@ where
     }
 }
 
-impl Decode for () {
-    fn decode<D: Decoder>(_: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for () {
+    fn decode<D: Decoder<Ctx = C>>(_: &mut D) -> Result<Self, DecodeError> {
         Ok(())
     }
 }
 impl_borrow_decode!(());
 
-impl<T> Decode for core::marker::PhantomData<T> {
-    fn decode<D: Decoder>(_: &mut D) -> Result<Self, DecodeError> {
+impl<C, T> Decode<C> for core::marker::PhantomData<T> {
+    fn decode<D: Decoder<Ctx = C>>(_: &mut D) -> Result<Self, DecodeError> {
         Ok(core::marker::PhantomData)
     }
 }
 impl_borrow_decode!(core::marker::PhantomData<T>, T);
 
-impl<T> Decode for Option<T>
+impl<C, T> Decode<C> for Option<T>
 where
-    T: Decode,
+    T: Decode<C>,
 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         match super::decode_option_variant(decoder, core::any::type_name::<Option<T>>())? {
             Some(_) => {
                 let val = T::decode(decoder)?;
@@ -567,12 +567,12 @@ where
     }
 }
 
-impl<T, U> Decode for Result<T, U>
+impl<C, T, U> Decode<C> for Result<T, U>
 where
-    T: Decode,
-    U: Decode,
+    T: Decode<C>,
+    U: Decode<C>,
 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let is_ok = u32::decode(decoder)?;
         match is_ok {
             0 => {
@@ -617,11 +617,11 @@ where
     }
 }
 
-impl<T> Decode for Cell<T>
+impl<C, T> Decode<C> for Cell<T>
 where
-    T: Decode,
+    T: Decode<C>,
 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let t = T::decode(decoder)?;
         Ok(Cell::new(t))
     }
@@ -637,11 +637,11 @@ where
     }
 }
 
-impl<T> Decode for RefCell<T>
+impl<C, T> Decode<C> for RefCell<T>
 where
-    T: Decode,
+    T: Decode<C>,
 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let t = T::decode(decoder)?;
         Ok(RefCell::new(t))
     }
@@ -657,8 +657,8 @@ where
     }
 }
 
-impl Decode for Duration {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<C> Decode<C> for Duration {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         const NANOS_PER_SEC: u64 = 1_000_000_000;
         let secs: u64 = Decode::decode(decoder)?;
         let nanos: u32 = Decode::decode(decoder)?;
@@ -670,11 +670,11 @@ impl Decode for Duration {
 }
 impl_borrow_decode!(Duration);
 
-impl<T> Decode for Range<T>
+impl<C, T> Decode<C> for Range<T>
 where
-    T: Decode,
+    T: Decode<C>,
 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let min = T::decode(decoder)?;
         let max = T::decode(decoder)?;
         Ok(min..max)
@@ -691,11 +691,11 @@ where
     }
 }
 
-impl<T> Decode for RangeInclusive<T>
+impl<C, T> Decode<C> for RangeInclusive<T>
 where
-    T: Decode,
+    T: Decode<C>,
 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let min = T::decode(decoder)?;
         let max = T::decode(decoder)?;
         Ok(RangeInclusive::new(min, max))
@@ -713,11 +713,11 @@ where
     }
 }
 
-impl<T> Decode for Bound<T>
+impl<T, C> Decode<C> for Bound<T>
 where
-    T: Decode,
+    T: Decode<C>,
 {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         match u32::decode(decoder)? {
             0 => Ok(Bound::Unbounded),
             1 => Ok(Bound::Included(T::decode(decoder)?)),

--- a/src/de/impls.rs
+++ b/src/de/impls.rs
@@ -18,8 +18,8 @@ use core::{
     time::Duration,
 };
 
-impl<C> Decode<C> for bool {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for bool {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         match u8::decode(decoder)? {
             0 => Ok(false),
             1 => Ok(true),
@@ -29,9 +29,9 @@ impl<C> Decode<C> for bool {
 }
 impl_borrow_decode!(bool);
 
-impl<C> Decode<C> for u8 {
+impl<Context> Decode<Context> for u8 {
     #[inline]
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(1)?;
         if let Some(buf) = decoder.reader().peek_read(1) {
             let byte = buf[0];
@@ -46,8 +46,8 @@ impl<C> Decode<C> for u8 {
 }
 impl_borrow_decode!(u8);
 
-impl<C> Decode<C> for NonZeroU8 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for NonZeroU8 {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroU8::new(u8::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::U8,
         })
@@ -55,8 +55,8 @@ impl<C> Decode<C> for NonZeroU8 {
 }
 impl_borrow_decode!(NonZeroU8);
 
-impl<C> Decode<C> for u16 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for u16 {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(2)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -75,8 +75,8 @@ impl<C> Decode<C> for u16 {
 }
 impl_borrow_decode!(u16);
 
-impl<C> Decode<C> for NonZeroU16 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for NonZeroU16 {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroU16::new(u16::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::U16,
         })
@@ -84,8 +84,8 @@ impl<C> Decode<C> for NonZeroU16 {
 }
 impl_borrow_decode!(NonZeroU16);
 
-impl<C> Decode<C> for u32 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for u32 {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(4)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -104,8 +104,8 @@ impl<C> Decode<C> for u32 {
 }
 impl_borrow_decode!(u32);
 
-impl<C> Decode<C> for NonZeroU32 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for NonZeroU32 {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroU32::new(u32::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::U32,
         })
@@ -113,8 +113,8 @@ impl<C> Decode<C> for NonZeroU32 {
 }
 impl_borrow_decode!(NonZeroU32);
 
-impl<C> Decode<C> for u64 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for u64 {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(8)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -133,8 +133,8 @@ impl<C> Decode<C> for u64 {
 }
 impl_borrow_decode!(u64);
 
-impl<C> Decode<C> for NonZeroU64 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for NonZeroU64 {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroU64::new(u64::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::U64,
         })
@@ -142,8 +142,8 @@ impl<C> Decode<C> for NonZeroU64 {
 }
 impl_borrow_decode!(NonZeroU64);
 
-impl<C> Decode<C> for u128 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for u128 {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(16)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -162,8 +162,8 @@ impl<C> Decode<C> for u128 {
 }
 impl_borrow_decode!(u128);
 
-impl<C> Decode<C> for NonZeroU128 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for NonZeroU128 {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroU128::new(u128::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::U128,
         })
@@ -171,8 +171,8 @@ impl<C> Decode<C> for NonZeroU128 {
 }
 impl_borrow_decode!(NonZeroU128);
 
-impl<C> Decode<C> for usize {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for usize {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(8)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -196,8 +196,8 @@ impl<C> Decode<C> for usize {
 }
 impl_borrow_decode!(usize);
 
-impl<C> Decode<C> for NonZeroUsize {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for NonZeroUsize {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroUsize::new(usize::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::Usize,
         })
@@ -205,8 +205,8 @@ impl<C> Decode<C> for NonZeroUsize {
 }
 impl_borrow_decode!(NonZeroUsize);
 
-impl<C> Decode<C> for i8 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for i8 {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(1)?;
         let mut bytes = [0u8; 1];
         decoder.reader().read(&mut bytes)?;
@@ -215,8 +215,8 @@ impl<C> Decode<C> for i8 {
 }
 impl_borrow_decode!(i8);
 
-impl<C> Decode<C> for NonZeroI8 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for NonZeroI8 {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroI8::new(i8::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::I8,
         })
@@ -224,8 +224,8 @@ impl<C> Decode<C> for NonZeroI8 {
 }
 impl_borrow_decode!(NonZeroI8);
 
-impl<C> Decode<C> for i16 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for i16 {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(2)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -244,8 +244,8 @@ impl<C> Decode<C> for i16 {
 }
 impl_borrow_decode!(i16);
 
-impl<C> Decode<C> for NonZeroI16 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for NonZeroI16 {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroI16::new(i16::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::I16,
         })
@@ -253,8 +253,8 @@ impl<C> Decode<C> for NonZeroI16 {
 }
 impl_borrow_decode!(NonZeroI16);
 
-impl<C> Decode<C> for i32 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for i32 {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(4)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -273,8 +273,8 @@ impl<C> Decode<C> for i32 {
 }
 impl_borrow_decode!(i32);
 
-impl<C> Decode<C> for NonZeroI32 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for NonZeroI32 {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroI32::new(i32::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::I32,
         })
@@ -282,8 +282,8 @@ impl<C> Decode<C> for NonZeroI32 {
 }
 impl_borrow_decode!(NonZeroI32);
 
-impl<C> Decode<C> for i64 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for i64 {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(8)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -302,8 +302,8 @@ impl<C> Decode<C> for i64 {
 }
 impl_borrow_decode!(i64);
 
-impl<C> Decode<C> for NonZeroI64 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for NonZeroI64 {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroI64::new(i64::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::I64,
         })
@@ -311,8 +311,8 @@ impl<C> Decode<C> for NonZeroI64 {
 }
 impl_borrow_decode!(NonZeroI64);
 
-impl<C> Decode<C> for i128 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for i128 {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(16)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -331,8 +331,8 @@ impl<C> Decode<C> for i128 {
 }
 impl_borrow_decode!(i128);
 
-impl<C> Decode<C> for NonZeroI128 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for NonZeroI128 {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroI128::new(i128::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::I128,
         })
@@ -340,8 +340,8 @@ impl<C> Decode<C> for NonZeroI128 {
 }
 impl_borrow_decode!(NonZeroI128);
 
-impl<C> Decode<C> for isize {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for isize {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(8)?;
         match D::C::INT_ENCODING {
             IntEncoding::Variable => {
@@ -360,8 +360,8 @@ impl<C> Decode<C> for isize {
 }
 impl_borrow_decode!(isize);
 
-impl<C> Decode<C> for NonZeroIsize {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for NonZeroIsize {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         NonZeroIsize::new(isize::decode(decoder)?).ok_or(DecodeError::NonZeroTypeIsZero {
             non_zero_type: IntegerType::Isize,
         })
@@ -369,8 +369,8 @@ impl<C> Decode<C> for NonZeroIsize {
 }
 impl_borrow_decode!(NonZeroIsize);
 
-impl<C> Decode<C> for f32 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for f32 {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(4)?;
         let mut bytes = [0u8; 4];
         decoder.reader().read(&mut bytes)?;
@@ -382,8 +382,8 @@ impl<C> Decode<C> for f32 {
 }
 impl_borrow_decode!(f32);
 
-impl<C> Decode<C> for f64 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for f64 {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(8)?;
         let mut bytes = [0u8; 8];
         decoder.reader().read(&mut bytes)?;
@@ -395,8 +395,8 @@ impl<C> Decode<C> for f64 {
 }
 impl_borrow_decode!(f64);
 
-impl<C, T: Decode<C>> Decode<C> for Wrapping<T> {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context, T: Decode<Context>> Decode<Context> for Wrapping<T> {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         Ok(Wrapping(T::decode(decoder)?))
     }
 }
@@ -408,8 +408,8 @@ impl<'de, Context, T: BorrowDecode<'de, Context>> BorrowDecode<'de, Context> for
     }
 }
 
-impl<C, T: Decode<C>> Decode<C> for Reverse<T> {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context, T: Decode<Context>> Decode<Context> for Reverse<T> {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         Ok(Reverse(T::decode(decoder)?))
     }
 }
@@ -422,8 +422,8 @@ impl<'de, Context, T: BorrowDecode<'de, Context>> BorrowDecode<'de, Context> for
     }
 }
 
-impl<C> Decode<C> for char {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for char {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let mut array = [0u8; 4];
 
         // Look at the first byte to see how many bytes must be read
@@ -471,11 +471,11 @@ impl<'a, 'de: 'a, Context> BorrowDecode<'de, Context> for &'a str {
     }
 }
 
-impl<C, T, const N: usize> Decode<C> for [T; N]
+impl<Context, T, const N: usize> Decode<Context> for [T; N]
 where
-    T: Decode<C>,
+    T: Decode<Context>,
 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         decoder.claim_bytes_read(core::mem::size_of::<[T; N]>())?;
 
         if unty::type_equal::<T, u8>() {
@@ -533,25 +533,25 @@ where
     }
 }
 
-impl<C> Decode<C> for () {
-    fn decode<D: Decoder<Context = C>>(_: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for () {
+    fn decode<D: Decoder<Context = Context>>(_: &mut D) -> Result<Self, DecodeError> {
         Ok(())
     }
 }
 impl_borrow_decode!(());
 
-impl<C, T> Decode<C> for core::marker::PhantomData<T> {
-    fn decode<D: Decoder<Context = C>>(_: &mut D) -> Result<Self, DecodeError> {
+impl<Context, T> Decode<Context> for core::marker::PhantomData<T> {
+    fn decode<D: Decoder<Context = Context>>(_: &mut D) -> Result<Self, DecodeError> {
         Ok(core::marker::PhantomData)
     }
 }
 impl_borrow_decode!(core::marker::PhantomData<T>, T);
 
-impl<C, T> Decode<C> for Option<T>
+impl<Context, T> Decode<Context> for Option<T>
 where
-    T: Decode<C>,
+    T: Decode<Context>,
 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         match super::decode_option_variant(decoder, core::any::type_name::<Option<T>>())? {
             Some(_) => {
                 let val = T::decode(decoder)?;
@@ -579,12 +579,12 @@ where
     }
 }
 
-impl<C, T, U> Decode<C> for Result<T, U>
+impl<Context, T, U> Decode<Context> for Result<T, U>
 where
-    T: Decode<C>,
-    U: Decode<C>,
+    T: Decode<Context>,
+    U: Decode<Context>,
 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let is_ok = u32::decode(decoder)?;
         match is_ok {
             0 => {
@@ -631,11 +631,11 @@ where
     }
 }
 
-impl<C, T> Decode<C> for Cell<T>
+impl<Context, T> Decode<Context> for Cell<T>
 where
-    T: Decode<C>,
+    T: Decode<Context>,
 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let t = T::decode(decoder)?;
         Ok(Cell::new(t))
     }
@@ -653,11 +653,11 @@ where
     }
 }
 
-impl<C, T> Decode<C> for RefCell<T>
+impl<Context, T> Decode<Context> for RefCell<T>
 where
-    T: Decode<C>,
+    T: Decode<Context>,
 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let t = T::decode(decoder)?;
         Ok(RefCell::new(t))
     }
@@ -675,8 +675,8 @@ where
     }
 }
 
-impl<C> Decode<C> for Duration {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for Duration {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         const NANOS_PER_SEC: u64 = 1_000_000_000;
         let secs: u64 = Decode::decode(decoder)?;
         let nanos: u32 = Decode::decode(decoder)?;
@@ -688,11 +688,11 @@ impl<C> Decode<C> for Duration {
 }
 impl_borrow_decode!(Duration);
 
-impl<C, T> Decode<C> for Range<T>
+impl<Context, T> Decode<Context> for Range<T>
 where
-    T: Decode<C>,
+    T: Decode<Context>,
 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let min = T::decode(decoder)?;
         let max = T::decode(decoder)?;
         Ok(min..max)
@@ -711,11 +711,11 @@ where
     }
 }
 
-impl<C, T> Decode<C> for RangeInclusive<T>
+impl<Context, T> Decode<Context> for RangeInclusive<T>
 where
-    T: Decode<C>,
+    T: Decode<Context>,
 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let min = T::decode(decoder)?;
         let max = T::decode(decoder)?;
         Ok(RangeInclusive::new(min, max))
@@ -735,11 +735,11 @@ where
     }
 }
 
-impl<T, C> Decode<C> for Bound<T>
+impl<T, Context> Decode<Context> for Bound<T>
 where
-    T: Decode<C>,
+    T: Decode<Context>,
 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         match u32::decode(decoder)? {
             0 => Ok(Bound::Unbounded),
             1 => Ok(Bound::Included(T::decode(decoder)?)),

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -82,9 +82,9 @@ pub use self::decoder::DecoderImpl;
 /// # }
 /// # bincode::impl_borrow_decode!(Foo);
 /// ```
-pub trait Decode: Sized {
+pub trait Decode<C = ()>: Sized {
     /// Attempt to decode this type with the given [Decode].
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError>;
+    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError>;
 }
 
 /// Trait that makes a type able to be decoded, akin to serde's `Deserialize` trait.
@@ -118,6 +118,8 @@ pub trait Decoder: Sealed {
 
     /// The concrete [Config] type
     type C: Config;
+
+    type Ctx;
 
     /// Returns a mutable reference to the reader
     fn reader(&mut self) -> &mut Self::R;
@@ -167,7 +169,7 @@ pub trait Decoder: Sealed {
     /// #     }
     /// # }
     /// impl<T: Decode> Decode for Container<T> {
-    ///     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+    ///     fn decode<D: Decoder<Ctx=C>>(decoder: &mut D) -> Result<Self, DecodeError> {
     ///         let len = u64::decode(decoder)?;
     ///         let len: usize = len.try_into().map_err(|_| DecodeError::OutsideUsizeRange(len))?;
     ///         // Make sure we don't allocate too much memory
@@ -222,6 +224,8 @@ where
     type R = T::R;
 
     type C = T::C;
+
+    type Ctx = T::Ctx;
 
     fn reader(&mut self) -> &mut Self::R {
         T::reader(self)

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -117,7 +117,7 @@ macro_rules! impl_borrow_decode {
 }
 
 #[macro_export]
-macro_rules! impl_borrow_decode_with_ctx {
+macro_rules! impl_borrow_decode_with_context {
     ($ty:ty, $context:ty $(, $param:tt)*) => {
         impl<'de $(, $param)*> $crate::BorrowDecode<'de, $context> for $ty {
             fn borrow_decode<D: $crate::de::BorrowDecoder<'de, Context = $context>>(
@@ -141,7 +141,7 @@ pub trait Decoder: Sealed {
 
     fn context(&mut self) -> &mut Self::Context;
 
-    fn with_ctx<'a, C>(&'a mut self, context: &'a mut C) -> WithContext<'a, Self, C> {
+    fn with_context<'a, C>(&'a mut self, context: &'a mut C) -> WithContext<'a, Self, C> {
         WithContext {
             decoder: self,
             context,

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -5,7 +5,10 @@ mod impl_core;
 mod impl_tuples;
 mod impls;
 
-use self::read::{BorrowReader, Reader};
+use self::{
+    decoder::WithContext,
+    read::{BorrowReader, Reader},
+};
 use crate::{
     config::{Config, InternalLimitConfig},
     error::DecodeError,
@@ -137,6 +140,10 @@ pub trait Decoder: Sealed {
     type Ctx;
 
     fn ctx(&mut self) -> &mut Self::Ctx;
+
+    fn with_ctx<'a, C>(&'a mut self, ctx: &'a mut C) -> WithContext<'a, Self, C> {
+        WithContext { decoder: self, ctx }
+    }
 
     /// Returns a mutable reference to the reader
     fn reader(&mut self) -> &mut Self::R;

--- a/src/features/impl_alloc.rs
+++ b/src/features/impl_alloc.rs
@@ -67,15 +67,15 @@ impl<C, T> Decode<C> for BinaryHeap<T>
 where
     T: Decode<C> + Ord,
 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         Ok(Vec::<T>::decode(decoder)?.into())
     }
 }
-impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for BinaryHeap<T>
+impl<'de, T, Context> BorrowDecode<'de, Context> for BinaryHeap<T>
 where
-    T: BorrowDecode<'de, Ctx> + Ord,
+    T: BorrowDecode<'de, Context> + Ord,
 {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         Ok(Vec::<T>::borrow_decode(decoder)?.into())
@@ -101,7 +101,7 @@ where
     K: Decode<C> + Ord,
     V: Decode<C>,
 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let len = crate::de::decode_slice_len(decoder)?;
         decoder.claim_container_read::<(K, V)>(len)?;
 
@@ -117,12 +117,12 @@ where
         Ok(map)
     }
 }
-impl<'de, K, V, Ctx> BorrowDecode<'de, Ctx> for BTreeMap<K, V>
+impl<'de, K, V, Context> BorrowDecode<'de, Context> for BTreeMap<K, V>
 where
-    K: BorrowDecode<'de, Ctx> + Ord,
-    V: BorrowDecode<'de, Ctx>,
+    K: BorrowDecode<'de, Context> + Ord,
+    V: BorrowDecode<'de, Context>,
 {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         let len = crate::de::decode_slice_len(decoder)?;
@@ -160,7 +160,7 @@ impl<C, T> Decode<C> for BTreeSet<T>
 where
     T: Decode<C> + Ord,
 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let len = crate::de::decode_slice_len(decoder)?;
         decoder.claim_container_read::<T>(len)?;
 
@@ -175,11 +175,11 @@ where
         Ok(map)
     }
 }
-impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for BTreeSet<T>
+impl<'de, T, Context> BorrowDecode<'de, Context> for BTreeSet<T>
 where
-    T: BorrowDecode<'de, Ctx> + Ord,
+    T: BorrowDecode<'de, Context> + Ord,
 {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         let len = crate::de::decode_slice_len(decoder)?;
@@ -214,15 +214,15 @@ impl<C, T> Decode<C> for VecDeque<T>
 where
     T: Decode<C>,
 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         Ok(Vec::<T>::decode(decoder)?.into())
     }
 }
-impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for VecDeque<T>
+impl<'de, T, Context> BorrowDecode<'de, Context> for VecDeque<T>
 where
-    T: BorrowDecode<'de, Ctx>,
+    T: BorrowDecode<'de, Context>,
 {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         Ok(Vec::<T>::borrow_decode(decoder)?.into())
@@ -260,7 +260,7 @@ impl<C, T> Decode<C> for Vec<T>
 where
     T: Decode<C>,
 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let len = crate::de::decode_slice_len(decoder)?;
 
         if unty::type_equal::<T, u8>() {
@@ -285,11 +285,11 @@ where
     }
 }
 
-impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for Vec<T>
+impl<'de, T, Context> BorrowDecode<'de, Context> for Vec<T>
 where
-    T: BorrowDecode<'de, Ctx>,
+    T: BorrowDecode<'de, Context>,
 {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         let len = crate::de::decode_slice_len(decoder)?;
@@ -337,7 +337,7 @@ where
 }
 
 impl<C> Decode<C> for String {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let bytes = Vec::<u8>::decode(decoder)?;
         String::from_utf8(bytes).map_err(|e| DecodeError::Utf8 {
             inner: e.utf8_error(),
@@ -347,7 +347,7 @@ impl<C> Decode<C> for String {
 impl_borrow_decode!(String);
 
 impl<C> Decode<C> for Box<str> {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
         String::decode(decoder).map(String::into_boxed_str)
     }
 }
@@ -363,16 +363,16 @@ impl<C, T> Decode<C> for Box<T>
 where
     T: Decode<C>,
 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let t = T::decode(decoder)?;
         Ok(Box::new(t))
     }
 }
-impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for Box<T>
+impl<'de, T, Context> BorrowDecode<'de, Context> for Box<T>
 where
-    T: BorrowDecode<'de, Ctx>,
+    T: BorrowDecode<'de, Context>,
 {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         let t = T::borrow_decode(decoder)?;
@@ -393,17 +393,17 @@ impl<C, T> Decode<C> for Box<[T]>
 where
     T: Decode<C> + 'static,
 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let vec = Vec::decode(decoder)?;
         Ok(vec.into_boxed_slice())
     }
 }
 
-impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for Box<[T]>
+impl<'de, T, Context> BorrowDecode<'de, Context> for Box<[T]>
 where
-    T: BorrowDecode<'de, Ctx> + 'de,
+    T: BorrowDecode<'de, Context> + 'de,
 {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         let vec = Vec::borrow_decode(decoder)?;
@@ -416,17 +416,17 @@ where
     T: ToOwned + ?Sized,
     <T as ToOwned>::Owned: Decode<C>,
 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let t = <T as ToOwned>::Owned::decode(decoder)?;
         Ok(Cow::Owned(t))
     }
 }
-impl<'cow, T, Ctx> BorrowDecode<'cow, Ctx> for Cow<'cow, T>
+impl<'cow, T, Context> BorrowDecode<'cow, Context> for Cow<'cow, T>
 where
     T: ToOwned + ?Sized,
-    &'cow T: BorrowDecode<'cow, Ctx>,
+    &'cow T: BorrowDecode<'cow, Context>,
 {
-    fn borrow_decode<D: BorrowDecoder<'cow, Ctx = Ctx>>(
+    fn borrow_decode<D: BorrowDecoder<'cow, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         let t = <&T>::borrow_decode(decoder)?;
@@ -461,24 +461,24 @@ impl<C, T> Decode<C> for Rc<T>
 where
     T: Decode<C>,
 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let t = T::decode(decoder)?;
         Ok(Rc::new(t))
     }
 }
 
 impl<C> Decode<C> for Rc<str> {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let decoded = String::decode(decoder)?;
         Ok(decoded.into())
     }
 }
 
-impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for Rc<T>
+impl<'de, T, Context> BorrowDecode<'de, Context> for Rc<T>
 where
-    T: BorrowDecode<'de, Ctx>,
+    T: BorrowDecode<'de, Context>,
 {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         let t = T::borrow_decode(decoder)?;
@@ -486,8 +486,8 @@ where
     }
 }
 
-impl<'de, Ctx> BorrowDecode<'de, Ctx> for Rc<str> {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+impl<'de, Context> BorrowDecode<'de, Context> for Rc<str> {
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         let decoded = String::decode(decoder)?;
@@ -508,17 +508,17 @@ impl<C, T> Decode<C> for Rc<[T]>
 where
     T: Decode<C> + 'static,
 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let vec = Vec::decode(decoder)?;
         Ok(vec.into())
     }
 }
 
-impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for Rc<[T]>
+impl<'de, T, Context> BorrowDecode<'de, Context> for Rc<[T]>
 where
-    T: BorrowDecode<'de, Ctx> + 'de,
+    T: BorrowDecode<'de, Context> + 'de,
 {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         let vec = Vec::borrow_decode(decoder)?;
@@ -531,7 +531,7 @@ impl<C, T> Decode<C> for Arc<T>
 where
     T: Decode<C>,
 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let t = T::decode(decoder)?;
         Ok(Arc::new(t))
     }
@@ -539,18 +539,18 @@ where
 
 #[cfg(target_has_atomic = "ptr")]
 impl<C> Decode<C> for Arc<str> {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let decoded = String::decode(decoder)?;
         Ok(decoded.into())
     }
 }
 
 #[cfg(target_has_atomic = "ptr")]
-impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for Arc<T>
+impl<'de, T, Context> BorrowDecode<'de, Context> for Arc<T>
 where
-    T: BorrowDecode<'de, Ctx>,
+    T: BorrowDecode<'de, Context>,
 {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         let t = T::borrow_decode(decoder)?;
@@ -559,8 +559,8 @@ where
 }
 
 #[cfg(target_has_atomic = "ptr")]
-impl<'de, Ctx> BorrowDecode<'de, Ctx> for Arc<str> {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+impl<'de, Context> BorrowDecode<'de, Context> for Arc<str> {
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         let decoded = String::decode(decoder)?;
@@ -583,18 +583,18 @@ impl<C, T> Decode<C> for Arc<[T]>
 where
     T: Decode<C> + 'static,
 {
-    fn decode<D: Decoder<Ctx = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let vec = Vec::decode(decoder)?;
         Ok(vec.into())
     }
 }
 
 #[cfg(target_has_atomic = "ptr")]
-impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for Arc<[T]>
+impl<'de, T, Context> BorrowDecode<'de, Context> for Arc<[T]>
 where
-    T: BorrowDecode<'de, Ctx> + 'de,
+    T: BorrowDecode<'de, Context> + 'de,
 {
-    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         let vec = Vec::borrow_decode(decoder)?;

--- a/src/features/impl_alloc.rs
+++ b/src/features/impl_alloc.rs
@@ -71,11 +71,13 @@ where
         Ok(Vec::<T>::decode(decoder)?.into())
     }
 }
-impl<'de, T> BorrowDecode<'de> for BinaryHeap<T>
+impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for BinaryHeap<T>
 where
-    T: BorrowDecode<'de> + Ord,
+    T: BorrowDecode<'de, Ctx> + Ord,
 {
-    fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
         Ok(Vec::<T>::borrow_decode(decoder)?.into())
     }
 }
@@ -115,12 +117,14 @@ where
         Ok(map)
     }
 }
-impl<'de, K, V> BorrowDecode<'de> for BTreeMap<K, V>
+impl<'de, K, V, Ctx> BorrowDecode<'de, Ctx> for BTreeMap<K, V>
 where
-    K: BorrowDecode<'de> + Ord,
-    V: BorrowDecode<'de>,
+    K: BorrowDecode<'de, Ctx> + Ord,
+    V: BorrowDecode<'de, Ctx>,
 {
-    fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
         let len = crate::de::decode_slice_len(decoder)?;
         decoder.claim_container_read::<(K, V)>(len)?;
 
@@ -171,11 +175,13 @@ where
         Ok(map)
     }
 }
-impl<'de, T> BorrowDecode<'de> for BTreeSet<T>
+impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for BTreeSet<T>
 where
-    T: BorrowDecode<'de> + Ord,
+    T: BorrowDecode<'de, Ctx> + Ord,
 {
-    fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
         let len = crate::de::decode_slice_len(decoder)?;
         decoder.claim_container_read::<T>(len)?;
 
@@ -212,11 +218,13 @@ where
         Ok(Vec::<T>::decode(decoder)?.into())
     }
 }
-impl<'de, T> BorrowDecode<'de> for VecDeque<T>
+impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for VecDeque<T>
 where
-    T: BorrowDecode<'de>,
+    T: BorrowDecode<'de, Ctx>,
 {
-    fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
         Ok(Vec::<T>::borrow_decode(decoder)?.into())
     }
 }
@@ -277,11 +285,13 @@ where
     }
 }
 
-impl<'de, T> BorrowDecode<'de> for Vec<T>
+impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for Vec<T>
 where
-    T: BorrowDecode<'de>,
+    T: BorrowDecode<'de, Ctx>,
 {
-    fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
         let len = crate::de::decode_slice_len(decoder)?;
 
         if unty::type_equal::<T, u8>() {
@@ -358,11 +368,13 @@ where
         Ok(Box::new(t))
     }
 }
-impl<'de, T> BorrowDecode<'de> for Box<T>
+impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for Box<T>
 where
-    T: BorrowDecode<'de>,
+    T: BorrowDecode<'de, Ctx>,
 {
-    fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
         let t = T::borrow_decode(decoder)?;
         Ok(Box::new(t))
     }
@@ -387,11 +399,13 @@ where
     }
 }
 
-impl<'de, T> BorrowDecode<'de> for Box<[T]>
+impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for Box<[T]>
 where
-    T: BorrowDecode<'de> + 'de,
+    T: BorrowDecode<'de, Ctx> + 'de,
 {
-    fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
         let vec = Vec::borrow_decode(decoder)?;
         Ok(vec.into_boxed_slice())
     }
@@ -407,12 +421,14 @@ where
         Ok(Cow::Owned(t))
     }
 }
-impl<'cow, T> BorrowDecode<'cow> for Cow<'cow, T>
+impl<'cow, T, Ctx> BorrowDecode<'cow, Ctx> for Cow<'cow, T>
 where
     T: ToOwned + ?Sized,
-    &'cow T: BorrowDecode<'cow>,
+    &'cow T: BorrowDecode<'cow, Ctx>,
 {
-    fn borrow_decode<D: BorrowDecoder<'cow>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn borrow_decode<D: BorrowDecoder<'cow, Ctx = Ctx>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
         let t = <&T>::borrow_decode(decoder)?;
         Ok(Cow::Borrowed(t))
     }
@@ -458,18 +474,22 @@ impl<C> Decode<C> for Rc<str> {
     }
 }
 
-impl<'de, T> BorrowDecode<'de> for Rc<T>
+impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for Rc<T>
 where
-    T: BorrowDecode<'de>,
+    T: BorrowDecode<'de, Ctx>,
 {
-    fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
         let t = T::borrow_decode(decoder)?;
         Ok(Rc::new(t))
     }
 }
 
-impl<'de> BorrowDecode<'de> for Rc<str> {
-    fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<'de, Ctx> BorrowDecode<'de, Ctx> for Rc<str> {
+    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
         let decoded = String::decode(decoder)?;
         Ok(decoded.into())
     }
@@ -494,11 +514,13 @@ where
     }
 }
 
-impl<'de, T> BorrowDecode<'de> for Rc<[T]>
+impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for Rc<[T]>
 where
-    T: BorrowDecode<'de> + 'de,
+    T: BorrowDecode<'de, Ctx> + 'de,
 {
-    fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
         let vec = Vec::borrow_decode(decoder)?;
         Ok(vec.into())
     }
@@ -524,19 +546,23 @@ impl<C> Decode<C> for Arc<str> {
 }
 
 #[cfg(target_has_atomic = "ptr")]
-impl<'de, T> BorrowDecode<'de> for Arc<T>
+impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for Arc<T>
 where
-    T: BorrowDecode<'de>,
+    T: BorrowDecode<'de, Ctx>,
 {
-    fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
         let t = T::borrow_decode(decoder)?;
         Ok(Arc::new(t))
     }
 }
 
 #[cfg(target_has_atomic = "ptr")]
-impl<'de> BorrowDecode<'de> for Arc<str> {
-    fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<'de, Ctx> BorrowDecode<'de, Ctx> for Arc<str> {
+    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
         let decoded = String::decode(decoder)?;
         Ok(decoded.into())
     }
@@ -564,11 +590,13 @@ where
 }
 
 #[cfg(target_has_atomic = "ptr")]
-impl<'de, T> BorrowDecode<'de> for Arc<[T]>
+impl<'de, T, Ctx> BorrowDecode<'de, Ctx> for Arc<[T]>
 where
-    T: BorrowDecode<'de> + 'de,
+    T: BorrowDecode<'de, Ctx> + 'de,
 {
-    fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn borrow_decode<D: BorrowDecoder<'de, Ctx = Ctx>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
         let vec = Vec::borrow_decode(decoder)?;
         Ok(vec.into())
     }

--- a/src/features/impl_std.rs
+++ b/src/features/impl_std.rs
@@ -27,11 +27,16 @@ pub fn decode_from_std_read<D: Decode<()>, C: Config, R: std::io::Read>(
     src: &mut R,
     config: C,
 ) -> Result<D, DecodeError> {
-    decode_from_std_read_with_ctx(src, config, ())
+    decode_from_std_read_with_context(src, config, ())
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-pub fn decode_from_std_read_with_ctx<Context, D: Decode<Context>, C: Config, R: std::io::Read>(
+pub fn decode_from_std_read_with_context<
+    Context,
+    D: Decode<Context>,
+    C: Config,
+    R: std::io::Read,
+>(
     src: &mut R,
     config: C,
     context: Context,

--- a/src/features/impl_std.rs
+++ b/src/features/impl_std.rs
@@ -149,8 +149,8 @@ impl Encode for CString {
     }
 }
 
-impl<C> Decode<C> for CString {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for CString {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let vec = std::vec::Vec::decode(decoder)?;
         CString::new(vec).map_err(|inner| DecodeError::CStringNulError {
             position: inner.nul_position(),
@@ -237,8 +237,8 @@ impl Encode for SystemTime {
     }
 }
 
-impl<C> Decode<C> for SystemTime {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for SystemTime {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let duration = Duration::decode(decoder)?;
         match SystemTime::UNIX_EPOCH.checked_add(duration) {
             Some(t) => Ok(t),
@@ -272,8 +272,8 @@ impl Encode for PathBuf {
     }
 }
 
-impl<C> Decode<C> for PathBuf {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for PathBuf {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let string = std::string::String::decode(decoder)?;
         Ok(string.into())
     }
@@ -295,8 +295,8 @@ impl Encode for IpAddr {
     }
 }
 
-impl<C> Decode<C> for IpAddr {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for IpAddr {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         match u32::decode(decoder)? {
             0 => Ok(IpAddr::V4(Ipv4Addr::decode(decoder)?)),
             1 => Ok(IpAddr::V6(Ipv6Addr::decode(decoder)?)),
@@ -316,8 +316,8 @@ impl Encode for Ipv4Addr {
     }
 }
 
-impl<C> Decode<C> for Ipv4Addr {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for Ipv4Addr {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let mut buff = [0u8; 4];
         decoder.reader().read(&mut buff)?;
         Ok(Self::from(buff))
@@ -331,8 +331,8 @@ impl Encode for Ipv6Addr {
     }
 }
 
-impl<C> Decode<C> for Ipv6Addr {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for Ipv6Addr {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let mut buff = [0u8; 16];
         decoder.reader().read(&mut buff)?;
         Ok(Self::from(buff))
@@ -355,8 +355,8 @@ impl Encode for SocketAddr {
     }
 }
 
-impl<C> Decode<C> for SocketAddr {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for SocketAddr {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         match u32::decode(decoder)? {
             0 => Ok(SocketAddr::V4(SocketAddrV4::decode(decoder)?)),
             1 => Ok(SocketAddr::V6(SocketAddrV6::decode(decoder)?)),
@@ -377,8 +377,8 @@ impl Encode for SocketAddrV4 {
     }
 }
 
-impl<C> Decode<C> for SocketAddrV4 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for SocketAddrV4 {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let ip = Ipv4Addr::decode(decoder)?;
         let port = u16::decode(decoder)?;
         Ok(Self::new(ip, port))
@@ -393,8 +393,8 @@ impl Encode for SocketAddrV6 {
     }
 }
 
-impl<C> Decode<C> for SocketAddrV6 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for SocketAddrV6 {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let ip = Ipv6Addr::decode(decoder)?;
         let port = u16::decode(decoder)?;
         Ok(Self::new(ip, port, 0, 0))
@@ -485,12 +485,12 @@ where
     }
 }
 
-impl<C, T, S> Decode<C> for HashSet<T, S>
+impl<Context, T, S> Decode<Context> for HashSet<T, S>
 where
-    T: Decode<C> + Eq + Hash,
+    T: Decode<Context> + Eq + Hash,
     S: std::hash::BuildHasher + Default,
 {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let len = crate::de::decode_slice_len(decoder)?;
         decoder.claim_container_read::<T>(len)?;
 

--- a/src/features/impl_std.rs
+++ b/src/features/impl_std.rs
@@ -27,7 +27,7 @@ pub fn decode_from_std_read<D: Decode<()>, C: Config, R: std::io::Read>(
     src: &mut R,
     config: C,
 ) -> Result<D, DecodeError> {
-    decode_from_std_read_with_context(src, config, ())
+    decode_from_std_read_with_context(src, config, &mut ())
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
@@ -39,7 +39,7 @@ pub fn decode_from_std_read_with_context<
 >(
     src: &mut R,
     config: C,
-    context: Context,
+    context: &mut Context,
 ) -> Result<D, DecodeError> {
     let reader = IoReader::new(src);
     let mut decoder = DecoderImpl::<_, C, Context>::new(reader, config, context);

--- a/src/features/serde/de_borrowed.rs
+++ b/src/features/serde/de_borrowed.rs
@@ -19,7 +19,7 @@ where
     C: Config,
 {
     let reader = crate::de::read::SliceReader::new(slice);
-    let mut decoder = crate::de::DecoderImpl::new(reader, config);
+    let mut decoder = crate::de::DecoderImpl::new(reader, config, ());
     let serde_decoder = SerdeDecoder {
         de: &mut decoder,
         pd: PhantomData,
@@ -37,7 +37,7 @@ where
     C: Config,
 {
     let reader = crate::de::read::SliceReader::new(slice);
-    let mut decoder = crate::de::DecoderImpl::new(reader, config);
+    let mut decoder = crate::de::DecoderImpl::new(reader, config, ());
     let serde_decoder = SerdeDecoder {
         de: &mut decoder,
         pd: PhantomData,
@@ -56,7 +56,7 @@ where
     C: Config,
 {
     let reader = crate::de::read::SliceReader::new(slice);
-    let mut decoder = crate::de::DecoderImpl::new(reader, config);
+    let mut decoder = crate::de::DecoderImpl::new(reader, config, ());
     let serde_decoder = SerdeDecoder {
         de: &mut decoder,
         pd: PhantomData,

--- a/src/features/serde/de_borrowed.rs
+++ b/src/features/serde/de_borrowed.rs
@@ -19,7 +19,8 @@ where
     C: Config,
 {
     let reader = crate::de::read::SliceReader::new(slice);
-    let mut decoder = crate::de::DecoderImpl::new(reader, config, ());
+    let mut context = ();
+    let mut decoder = crate::de::DecoderImpl::new(reader, config, &mut context);
     let serde_decoder = SerdeDecoder {
         de: &mut decoder,
         pd: PhantomData,
@@ -37,7 +38,8 @@ where
     C: Config,
 {
     let reader = crate::de::read::SliceReader::new(slice);
-    let mut decoder = crate::de::DecoderImpl::new(reader, config, ());
+    let mut context = ();
+    let mut decoder = crate::de::DecoderImpl::new(reader, config,  &mut context);
     let serde_decoder = SerdeDecoder {
         de: &mut decoder,
         pd: PhantomData,
@@ -56,7 +58,8 @@ where
     C: Config,
 {
     let reader = crate::de::read::SliceReader::new(slice);
-    let mut decoder = crate::de::DecoderImpl::new(reader, config, ());
+    let mut context = ();
+    let mut decoder = crate::de::DecoderImpl::new(reader, config, &mut context);
     let serde_decoder = SerdeDecoder {
         de: &mut decoder,
         pd: PhantomData,

--- a/src/features/serde/de_owned.rs
+++ b/src/features/serde/de_owned.rs
@@ -20,7 +20,8 @@ where
     C: Config,
 {
     let reader = crate::de::read::SliceReader::new(slice);
-    let mut decoder = crate::de::DecoderImpl::new(reader, config, ());
+    let mut context = ();
+    let mut decoder = crate::de::DecoderImpl::new(reader, config, &mut context);
     let serde_decoder = SerdeDecoder { de: &mut decoder };
     let result = D::deserialize(serde_decoder)?;
     let bytes_read = slice.len() - decoder.reader().slice.len();
@@ -39,7 +40,8 @@ pub fn decode_from_std_read<D: DeserializeOwned, C: Config, R: std::io::Read>(
     config: C,
 ) -> Result<D, DecodeError> {
     let reader = crate::IoReader::new(src);
-    let mut decoder = crate::de::DecoderImpl::new(reader, config, ());
+    let mut context = ();
+    let mut decoder = crate::de::DecoderImpl::new(reader, config, &mut context);
     let serde_decoder = SerdeDecoder { de: &mut decoder };
     D::deserialize(serde_decoder)
 }
@@ -53,7 +55,8 @@ pub fn decode_from_reader<D: DeserializeOwned, R: Reader, C: Config>(
     reader: R,
     config: C,
 ) -> Result<D, DecodeError> {
-    let mut decoder = crate::de::DecoderImpl::<_, C, ()>::new(reader, config, ());
+    let mut context = ();
+    let mut decoder = crate::de::DecoderImpl::<_, C, ()>::new(reader, config, &mut context);
     let serde_decoder = SerdeDecoder { de: &mut decoder };
     D::deserialize(serde_decoder)
 }

--- a/src/features/serde/de_owned.rs
+++ b/src/features/serde/de_owned.rs
@@ -20,7 +20,7 @@ where
     C: Config,
 {
     let reader = crate::de::read::SliceReader::new(slice);
-    let mut decoder = crate::de::DecoderImpl::new(reader, config);
+    let mut decoder = crate::de::DecoderImpl::new(reader, config, ());
     let serde_decoder = SerdeDecoder { de: &mut decoder };
     let result = D::deserialize(serde_decoder)?;
     let bytes_read = slice.len() - decoder.reader().slice.len();
@@ -39,7 +39,7 @@ pub fn decode_from_std_read<D: DeserializeOwned, C: Config, R: std::io::Read>(
     config: C,
 ) -> Result<D, DecodeError> {
     let reader = crate::IoReader::new(src);
-    let mut decoder = crate::de::DecoderImpl::new(reader, config);
+    let mut decoder = crate::de::DecoderImpl::new(reader, config, ());
     let serde_decoder = SerdeDecoder { de: &mut decoder };
     D::deserialize(serde_decoder)
 }
@@ -53,7 +53,7 @@ pub fn decode_from_reader<D: DeserializeOwned, R: Reader, C: Config>(
     reader: R,
     config: C,
 ) -> Result<D, DecodeError> {
-    let mut decoder = crate::de::DecoderImpl::<_, C>::new(reader, config);
+    let mut decoder = crate::de::DecoderImpl::<_, C, ()>::new(reader, config, ());
     let serde_decoder = SerdeDecoder { de: &mut decoder };
     D::deserialize(serde_decoder)
 }

--- a/src/features/serde/mod.rs
+++ b/src/features/serde/mod.rs
@@ -182,7 +182,7 @@ impl serde::ser::Error for crate::error::EncodeError {
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Compat<T>(pub T);
 
-impl<Ctx, T> crate::Decode<Ctx> for Compat<T>
+impl<Context, T> crate::Decode<Context> for Compat<T>
 where
     T: serde::de::DeserializeOwned,
 {
@@ -191,7 +191,7 @@ where
         T::deserialize(serde_decoder).map(Compat)
     }
 }
-impl<'de, T, Ctx> crate::BorrowDecode<'de, Ctx> for Compat<T>
+impl<'de, T, Context> crate::BorrowDecode<'de, Context> for Compat<T>
 where
     T: serde::de::DeserializeOwned,
 {
@@ -244,7 +244,7 @@ where
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct BorrowCompat<T>(pub T);
 
-impl<'de, T, Ctx> crate::de::BorrowDecode<'de, Ctx> for BorrowCompat<T>
+impl<'de, T, Context> crate::de::BorrowDecode<'de, Context> for BorrowCompat<T>
 where
     T: serde::de::Deserialize<'de>,
 {

--- a/src/features/serde/mod.rs
+++ b/src/features/serde/mod.rs
@@ -182,7 +182,7 @@ impl serde::ser::Error for crate::error::EncodeError {
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Compat<T>(pub T);
 
-impl<T> crate::Decode for Compat<T>
+impl<Ctx, T> crate::Decode<Ctx> for Compat<T>
 where
     T: serde::de::DeserializeOwned,
 {
@@ -191,7 +191,7 @@ where
         T::deserialize(serde_decoder).map(Compat)
     }
 }
-impl<'de, T> crate::BorrowDecode<'de> for Compat<T>
+impl<'de, T, Ctx> crate::BorrowDecode<'de, Ctx> for Compat<T>
 where
     T: serde::de::DeserializeOwned,
 {
@@ -244,7 +244,7 @@ where
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct BorrowCompat<T>(pub T);
 
-impl<'de, T> crate::de::BorrowDecode<'de> for BorrowCompat<T>
+impl<'de, T, Ctx> crate::de::BorrowDecode<'de, Ctx> for BorrowCompat<T>
 where
     T: serde::de::Deserialize<'de>,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,8 +149,16 @@ pub fn decode_from_slice<D: de::Decode, C: Config>(
     src: &[u8],
     config: C,
 ) -> Result<(D, usize), error::DecodeError> {
+    decode_from_slice_with_ctx(src, config, ())
+}
+
+pub fn decode_from_slice_with_ctx<Ctx, D: de::Decode<Ctx>, C: Config>(
+    src: &[u8],
+    config: C,
+    ctx: Ctx,
+) -> Result<(D, usize), error::DecodeError> {
     let reader = de::read::SliceReader::new(src);
-    let mut decoder = de::DecoderImpl::<_, C>::new(reader, config);
+    let mut decoder = de::DecoderImpl::<_, C, Ctx>::new(reader, config, ctx);
     let result = D::decode(&mut decoder)?;
     let bytes_read = src.len() - decoder.reader().slice.len();
     Ok((result, bytes_read))
@@ -166,7 +174,7 @@ pub fn borrow_decode_from_slice<'a, D: de::BorrowDecode<'a>, C: Config>(
     config: C,
 ) -> Result<(D, usize), error::DecodeError> {
     let reader = de::read::SliceReader::new(src);
-    let mut decoder = de::DecoderImpl::<_, C>::new(reader, config);
+    let mut decoder = de::DecoderImpl::<_, C, ()>::new(reader, config, ());
     let result = D::borrow_decode(&mut decoder)?;
     let bytes_read = src.len() - decoder.reader().slice.len();
     Ok((result, bytes_read))
@@ -181,7 +189,7 @@ pub fn decode_from_reader<D: de::Decode, R: Reader, C: Config>(
     reader: R,
     config: C,
 ) -> Result<D, error::DecodeError> {
-    let mut decoder = de::DecoderImpl::<_, C>::new(reader, config);
+    let mut decoder = de::DecoderImpl::<_, C, ()>::new(reader, config, ());
     D::decode(&mut decoder)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,16 +149,16 @@ pub fn decode_from_slice<D: de::Decode<()>, C: Config>(
     src: &[u8],
     config: C,
 ) -> Result<(D, usize), error::DecodeError> {
-    decode_from_slice_with_ctx(src, config, ())
+    decode_from_slice_with_context(src, config, ())
 }
 
-pub fn decode_from_slice_with_ctx<Ctx, D: de::Decode<Ctx>, C: Config>(
+pub fn decode_from_slice_with_context<Context, D: de::Decode<Context>, C: Config>(
     src: &[u8],
     config: C,
-    ctx: Ctx,
+    context: Context,
 ) -> Result<(D, usize), error::DecodeError> {
     let reader = de::read::SliceReader::new(src);
-    let mut decoder = de::DecoderImpl::<_, C, Ctx>::new(reader, config, ctx);
+    let mut decoder = de::DecoderImpl::<_, C, Context>::new(reader, config, context);
     let result = D::decode(&mut decoder)?;
     let bytes_read = src.len() - decoder.reader().slice.len();
     Ok((result, bytes_read))
@@ -176,13 +176,18 @@ pub fn borrow_decode_from_slice<'a, D: de::BorrowDecode<'a, ()>, C: Config>(
     borrow_decode_from_slice_with_context(src, config, ())
 }
 
-pub fn borrow_decode_from_slice_with_context<'a, Ctx, D: de::BorrowDecode<'a, Ctx>, C: Config>(
+pub fn borrow_decode_from_slice_with_context<
+    'a,
+    Context,
+    D: de::BorrowDecode<'a, Context>,
+    C: Config,
+>(
     src: &'a [u8],
     config: C,
-    ctx: Ctx,
+    context: Context,
 ) -> Result<(D, usize), error::DecodeError> {
     let reader = de::read::SliceReader::new(src);
-    let mut decoder = de::DecoderImpl::<_, C, Ctx>::new(reader, config, ctx);
+    let mut decoder = de::DecoderImpl::<_, C, Context>::new(reader, config, context);
     let result = D::borrow_decode(&mut decoder)?;
     let bytes_read = src.len() - decoder.reader().slice.len();
     Ok((result, bytes_read))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,13 +149,13 @@ pub fn decode_from_slice<D: de::Decode<()>, C: Config>(
     src: &[u8],
     config: C,
 ) -> Result<(D, usize), error::DecodeError> {
-    decode_from_slice_with_context(src, config, ())
+    decode_from_slice_with_context(src, config, &mut ())
 }
 
 pub fn decode_from_slice_with_context<Context, D: de::Decode<Context>, C: Config>(
     src: &[u8],
     config: C,
-    context: Context,
+    context: &mut Context,
 ) -> Result<(D, usize), error::DecodeError> {
     let reader = de::read::SliceReader::new(src);
     let mut decoder = de::DecoderImpl::<_, C, Context>::new(reader, config, context);
@@ -173,7 +173,7 @@ pub fn borrow_decode_from_slice<'a, D: de::BorrowDecode<'a, ()>, C: Config>(
     src: &'a [u8],
     config: C,
 ) -> Result<(D, usize), error::DecodeError> {
-    borrow_decode_from_slice_with_context(src, config, ())
+    borrow_decode_from_slice_with_context(src, config, &mut ())
 }
 
 pub fn borrow_decode_from_slice_with_context<
@@ -184,7 +184,7 @@ pub fn borrow_decode_from_slice_with_context<
 >(
     src: &'a [u8],
     config: C,
-    context: Context,
+    context: &mut Context,
 ) -> Result<(D, usize), error::DecodeError> {
     let reader = de::read::SliceReader::new(src);
     let mut decoder = de::DecoderImpl::<_, C, Context>::new(reader, config, context);
@@ -202,7 +202,8 @@ pub fn decode_from_reader<D: de::Decode<()>, R: Reader, C: Config>(
     reader: R,
     config: C,
 ) -> Result<D, error::DecodeError> {
-    let mut decoder = de::DecoderImpl::<_, C, ()>::new(reader, config, ());
+    let mut context = ();
+    let mut decoder = de::DecoderImpl::<_, C, ()>::new(reader, config, &mut context);
     D::decode(&mut decoder)
 }
 

--- a/tests/alloc.rs
+++ b/tests/alloc.rs
@@ -145,7 +145,9 @@ fn test_container_limits() {
         bincode::encode_to_vec(DECODE_LIMIT as u64, bincode::config::standard()).unwrap(),
     ];
 
-    fn validate_fail<T: Decode + for<'de> BorrowDecode<'de> + core::fmt::Debug>(slice: &[u8]) {
+    fn validate_fail<T: Decode<()> + for<'de> BorrowDecode<'de, ()> + core::fmt::Debug>(
+        slice: &[u8],
+    ) {
         let result = bincode::decode_from_slice::<T, _>(
             slice,
             bincode::config::standard().with_limit::<DECODE_LIMIT>(),

--- a/tests/alloc.rs
+++ b/tests/alloc.rs
@@ -29,7 +29,7 @@ impl bincode::Encode for Foo {
     }
 }
 
-impl bincode::Decode for Foo {
+impl<C> bincode::Decode<C> for Foo {
     fn decode<D: bincode::de::Decoder>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {

--- a/tests/alloc.rs
+++ b/tests/alloc.rs
@@ -29,7 +29,7 @@ impl bincode::Encode for Foo {
     }
 }
 
-impl<C> bincode::Decode<C> for Foo {
+impl<Context> bincode::Decode<Context> for Foo {
     fn decode<D: bincode::de::Decoder>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {

--- a/tests/context.rs
+++ b/tests/context.rs
@@ -79,7 +79,7 @@ impl<Context> Decode<Context> for SelfReferencing {
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
         SelfReferencing::try_new(Bump::new(), |mut bump| {
-            Container::decode(&mut decoder.with_ctx(&mut bump))
+            Container::decode(&mut decoder.with_context(&mut bump))
         })
     }
 }

--- a/tests/context.rs
+++ b/tests/context.rs
@@ -96,7 +96,7 @@ fn decode_with_context() {
 
     let bytes = encode_to_vec(&container, config).unwrap();
     let (decoded_container, _) =
-        decode_from_slice_with_context::<_, Container, _>(&bytes, config, &bump).unwrap();
+        decode_from_slice_with_context::<_, Container, _>(&bytes, config, &mut &bump).unwrap();
 
     assert_eq!(container, decoded_container);
 

--- a/tests/context.rs
+++ b/tests/context.rs
@@ -74,8 +74,10 @@ struct SelfReferencing {
     container: Container<'this>,
 }
 
-impl<C> Decode<C> for SelfReferencing {
-    fn decode<D: bincode::de::Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+impl<Context> Decode<Context> for SelfReferencing {
+    fn decode<D: bincode::de::Decoder<Context = Context>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
         SelfReferencing::try_new(Bump::new(), |mut bump| {
             Container::decode(&mut decoder.with_ctx(&mut bump))
         })

--- a/tests/context.rs
+++ b/tests/context.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "alloc")]
+
 use bincode::{
     config, de::BorrowDecoder, decode_from_slice, decode_from_slice_with_context, encode_to_vec,
     error::DecodeError, BorrowDecode, Decode, Encode,

--- a/tests/ctx.rs
+++ b/tests/ctx.rs
@@ -1,0 +1,81 @@
+use bincode::{
+    config, de::BorrowDecoder, decode_from_slice_with_ctx, encode_to_vec, error::DecodeError,
+    BorrowDecode, Decode, Encode,
+};
+use bumpalo::{collections::Vec, vec, Bump};
+
+#[derive(PartialEq, Eq, Debug)]
+struct CodableVec<'bump, T: 'bump>(Vec<'bump, T>);
+
+impl<'bump, T: Encode> Encode for CodableVec<'bump, T> {
+    fn encode<E: bincode::enc::Encoder>(
+        &self,
+        encoder: &mut E,
+    ) -> Result<(), bincode::error::EncodeError> {
+        self.0.as_slice().encode(encoder)
+    }
+}
+
+impl<'bump, T: Decode<&'bump Bump>> Decode<&'bump Bump> for CodableVec<'bump, T> {
+    fn decode<D: bincode::de::Decoder<Ctx = &'bump Bump>>(
+        decoder: &mut D,
+    ) -> Result<Self, bincode::error::DecodeError> {
+        let len = u64::decode(decoder)?;
+        let len = usize::try_from(len).map_err(|_| DecodeError::OutsideUsizeRange(len))?;
+        decoder.claim_container_read::<T>(len)?;
+        let mut vec = Vec::with_capacity_in(len, decoder.ctx());
+        for _ in 0..len {
+            decoder.unclaim_bytes_read(core::mem::size_of::<T>());
+            vec.push(T::decode(decoder)?);
+        }
+        Ok(Self(vec))
+    }
+}
+
+impl<'de, 'bump, T: BorrowDecode<'de, &'bump Bump>> BorrowDecode<'de, &'bump Bump>
+    for CodableVec<'bump, T>
+{
+    fn borrow_decode<D: BorrowDecoder<'de, Ctx = &'bump Bump>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
+        let len = u64::decode(decoder)?;
+        let len = usize::try_from(len).map_err(|_| DecodeError::OutsideUsizeRange(len))?;
+
+        decoder.claim_container_read::<T>(len)?;
+
+        let mut vec = Vec::with_capacity_in(len, decoder.ctx());
+        for _ in 0..len {
+            // See the documentation on `unclaim_bytes_read` as to why we're doing this here
+            decoder.unclaim_bytes_read(core::mem::size_of::<T>());
+
+            vec.push(T::borrow_decode(decoder)?);
+        }
+        Ok(Self(vec))
+    }
+}
+
+#[derive(Encode, Decode, PartialEq, Eq, Debug)]
+#[bincode(decode_context = "&'bump Bump")]
+struct Container<'bump> {
+    vec: CodableVec<'bump, u32>,
+}
+
+#[derive(Encode, Decode, PartialEq, Eq, Debug)]
+#[bincode(decode_context = "&'bump Bump")]
+enum _EnumContainer<'bump> {
+    Vec(CodableVec<'bump, u32>),
+}
+
+#[test]
+fn decode_with_context() {
+    let bump = Bump::new();
+    let container = Container {
+        vec: CodableVec(vec![in &bump; 1, 2, 3]),
+    };
+
+    let bytes = encode_to_vec(&container, config::standard()).unwrap();
+    let (decoded_container, _) =
+        decode_from_slice_with_ctx::<_, Container, _>(&bytes, config::standard(), &bump).unwrap();
+
+    assert_eq!(container, decoded_container);
+}

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -28,11 +28,11 @@ pub struct Test2<T> {
     b: u32,
     c: u32,
 }
-impl<T, Ctx> ::bincode::Decode<Ctx> for Test2<T>
+impl<T, Context> ::bincode::Decode<Context> for Test2<T>
 where
-    T: ::bincode::Decode<Ctx>,
+    T: ::bincode::Decode<Context>,
 {
-    fn decode<D: ::bincode::de::Decoder<Ctx = Ctx>>(
+    fn decode<D: ::bincode::de::Decoder<Context = Context>>(
         decoder: &mut D,
     ) -> core::result::Result<Self, ::bincode::error::DecodeError> {
         Ok(Self {
@@ -42,11 +42,11 @@ where
         })
     }
 }
-impl<'__de, T, Ctx> ::bincode::BorrowDecode<'__de, Ctx> for Test2<T>
+impl<'__de, T, Context> ::bincode::BorrowDecode<'__de, Context> for Test2<T>
 where
-    T: ::bincode::BorrowDecode<'__de, Ctx> + '__de,
+    T: ::bincode::BorrowDecode<'__de, Context> + '__de,
 {
-    fn borrow_decode<D: ::bincode::de::BorrowDecoder<'__de, Ctx = Ctx>>(
+    fn borrow_decode<D: ::bincode::de::BorrowDecoder<'__de, Context = Context>>(
         decoder: &mut D,
     ) -> core::result::Result<Self, ::bincode::error::DecodeError> {
         Ok(Self {

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -28,11 +28,11 @@ pub struct Test2<T> {
     b: u32,
     c: u32,
 }
-impl<T> ::bincode::Decode for Test2<T>
+impl<T, Ctx> ::bincode::Decode<Ctx> for Test2<T>
 where
-    T: ::bincode::Decode,
+    T: ::bincode::Decode<Ctx>,
 {
-    fn decode<D: ::bincode::de::Decoder>(
+    fn decode<D: ::bincode::de::Decoder<Ctx = Ctx>>(
         decoder: &mut D,
     ) -> core::result::Result<Self, ::bincode::error::DecodeError> {
         Ok(Self {
@@ -42,11 +42,11 @@ where
         })
     }
 }
-impl<'__de, T> ::bincode::BorrowDecode<'__de> for Test2<T>
+impl<'__de, T, Ctx> ::bincode::BorrowDecode<'__de, Ctx> for Test2<T>
 where
-    T: ::bincode::BorrowDecode<'__de> + '__de,
+    T: ::bincode::BorrowDecode<'__de, Ctx> + '__de,
 {
-    fn borrow_decode<D: ::bincode::de::BorrowDecoder<'__de>>(
+    fn borrow_decode<D: ::bincode::de::BorrowDecoder<'__de, Ctx = Ctx>>(
         decoder: &mut D,
     ) -> core::result::Result<Self, ::bincode::error::DecodeError> {
         Ok(Self {

--- a/tests/issues/issue_431.rs
+++ b/tests/issues/issue_431.rs
@@ -8,15 +8,19 @@ use std::string::String;
 
 #[derive(Decode, Encode, PartialEq, Debug)]
 #[bincode(
-    borrow_decode_bounds = "&'__de U<'a, A>: ::bincode::de::BorrowDecode<'__de> + '__de, '__de: 'a"
+    decode_context = "()",
+    borrow_decode_bounds = "&'__de U<'a, A>: ::bincode::de::BorrowDecode<'__de, ()> + '__de, '__de: 'a"
 )]
-struct T<'a, A: Clone + Encode + Decode> {
+struct T<'a, A: Clone + Encode + Decode<()>> {
     t: Cow<'a, U<'a, A>>,
 }
 
 #[derive(Clone, Decode, Encode, PartialEq, Debug)]
-#[bincode(borrow_decode_bounds = "&'__de A: ::bincode::de::BorrowDecode<'__de> + '__de, '__de: 'a")]
-struct U<'a, A: Clone + Encode + Decode> {
+#[bincode(
+    decode_context = "()",
+    borrow_decode_bounds = "&'__de A: ::bincode::de::BorrowDecode<'__de, ()> + '__de, '__de: 'a"
+)]
+struct U<'a, A: Clone + Encode + Decode<()>> {
     u: Cow<'a, A>,
 }
 

--- a/tests/issues/issue_614.rs
+++ b/tests/issues/issue_614.rs
@@ -7,7 +7,7 @@ pub struct A;
 #[derive(Encode, Decode, Clone)]
 pub struct B<T>
 where
-    T: Clone + Encode + Decode,
+    T: Clone + Encode + Decode<()>,
 {
     pub t: T,
 }
@@ -15,7 +15,7 @@ where
 #[derive(Encode, Decode)]
 pub struct MyStruct<T>
 where
-    T: Clone + Encode + Decode,
+    T: Clone + Encode + Decode<()>,
 {
     pub a: A,
     pub b: B<T>,

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -2,7 +2,6 @@
 
 extern crate alloc;
 
-use alloc::string::String;
 use serde_derive::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, bincode::Encode, bincode::Decode)]

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -174,7 +174,7 @@ mod derive {
     fn test_serde_derive() {
         fn test_encode_decode<T>(start: T, expected_len: usize)
         where
-            T: bincode::Encode + bincode::Decode + PartialEq + core::fmt::Debug,
+            T: bincode::Encode + bincode::Decode<()> + PartialEq + core::fmt::Debug,
         {
             let mut slice = [0u8; 100];
             let len = bincode::encode_into_slice(&start, &mut slice, bincode::config::standard())

--- a/tests/std.rs
+++ b/tests/std.rs
@@ -31,7 +31,7 @@ impl bincode::Encode for Foo {
     }
 }
 
-impl bincode::Decode for Foo {
+impl<Ctx> bincode::Decode<Ctx> for Foo {
     fn decode<D: bincode::de::Decoder>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {

--- a/tests/std.rs
+++ b/tests/std.rs
@@ -31,7 +31,7 @@ impl bincode::Encode for Foo {
     }
 }
 
-impl<Ctx> bincode::Decode<Ctx> for Foo {
+impl<Context> bincode::Decode<Context> for Foo {
     fn decode<D: bincode::de::Decoder>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -128,13 +128,18 @@ where
 
 #[cfg(feature = "serde")]
 pub trait TheSameTrait:
-    bincode::Encode + bincode::Decode + serde::de::DeserializeOwned + serde::Serialize + Debug + 'static
+    bincode::Encode
+    + bincode::Decode<()>
+    + serde::de::DeserializeOwned
+    + serde::Serialize
+    + Debug
+    + 'static
 {
 }
 #[cfg(feature = "serde")]
 impl<T> TheSameTrait for T where
     T: bincode::Encode
-        + bincode::Decode
+        + bincode::Decode<()>
         + serde::de::DeserializeOwned
         + serde::Serialize
         + Debug

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -148,9 +148,9 @@ impl<T> TheSameTrait for T where
 }
 
 #[cfg(not(feature = "serde"))]
-pub trait TheSameTrait: bincode::Encode + bincode::Decode + Debug + 'static {}
+pub trait TheSameTrait: bincode::Encode + bincode::Decode<()> + Debug + 'static {}
 #[cfg(not(feature = "serde"))]
-impl<T> TheSameTrait for T where T: bincode::Encode + bincode::Decode + Debug + 'static {}
+impl<T> TheSameTrait for T where T: bincode::Encode + bincode::Decode<()> + Debug + 'static {}
 
 #[allow(dead_code)] // This is not used in every test
 pub fn the_same<V: TheSameTrait + PartialEq>(element: V) {


### PR DESCRIPTION
## Why

With the current `Decode`/`BorrowDecode`, it's impossible to implement them on a type that borrows something other than the input data. A concrete example would be a [`Vec<'bump, T: 'bump>`](https://docs.rs/bumpalo/latest/bumpalo/collections/vec/struct.Vec.html) which is allocated by an arena allocator.

## How

This PR introduces the following changes:
- Add a decode function that accepts a decode context: `decode_from_slice_with_ctx<Ctx, D: de::Decode<Ctx>, C: Config>(src: &[u8], config: C, ctx: Ctx)`. In that arena `Vec` example, the decode context would be the allocator `&Bump`.
- The context is attached to `DecoderImpl` and exposed to `Decode` implements via `Decoder::ctx` method.
- `Decode` trait is changed to `Decode<C>`, which allows types to implement `Decode` only under some specific context. (`Vec<'bump, T: 'bump>` would implement `Decode<&'bump Bump>`)
- The derive macro `Decode` is changed to generating `impl<Ctx> Decode<Ctx> for ...` instead of `impl Decode for ...`. A container attribute `decode_context` is added to allow deriving `Decode` with a concrete context type. (for example `#[bincode(decode_context = "&'bump Bump")]`)
- All changes above are also similarly done to `BorrowDecoder`.

You can see how these changes work together in `tests/ctx.rs`.

I know this is a big change and would break existing `2.0.0` users. But it's still `rc` so I guess it's not too late to discuss it? ;)


## Alternative Design

Leaves `(Borrow)Decode` untouched, and add `(Borrow)DecodeWithContext<C>`. 

Pros:
- Less impactful. Non-breaking to `(Borrow)Decode`.
- Less cognitive overload to implementors who don't care about decode contexts.

Con:
- Trait explosion: https://github.com/bincode-org/bincode/issues/578#issuecomment-1233071687.
- Needs a separate derive macro.

## TODOs

This PR hasn't been polished to a mergeable state yet. I will do that if the overall design is accepted.

- Namings are not consistent (C?Ctx?Context? )
- Docs not updated
- virtue is updated to allow generating `impl<Ctx>`. This would need a separate PR.
- Current derive macro `Decode` allows `Ctx` to be either a concrete type or totally unbounded. How about allowing `Ctx: ...`? Is it useful enough to be implemented?
