### PR TITLE
Put clarifying language in migration guide regarding the serde:: and non-serde:: paths

### DIFF
--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -40,7 +40,9 @@ Because of confusion with `Options` defaults in bincode 1, we have made `Configu
 
 ## Migrating with `serde`
 
-Make sure to include bincode 2 with the `serde` feature enabled.
+You may wish to stick with `serde` when migrating to bincode 2, for example if you are using serde-exclusive derive features such as `#[serde(deserialize_with)]`.
+
+If so, make sure to include bincode 2 with the `serde` feature enabled.
 
 ```toml
 [dependencies]
@@ -62,7 +64,7 @@ Then replace the following functions: (`Configuration` is `bincode::config::lega
 | `bincode::serialize_into(std::io::Write, T)`    | `bincode::serde::encode_into_std_write(T, std::io::Write, Configuration)`                                                       |
 | `bincode::serialized_size(T)`                   | Currently not implemented                                                                                                       |
 
-## Migrating to `bincode-derive`
+## Migrating from `serde` to `bincode-derive`
 
 `bincode-derive` is enabled by default. If you're using `default-features = false`, make sure to add `features = ["derive"]` to your `Cargo.toml`.
 

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -42,7 +42,7 @@ Because of confusion with `Options` defaults in bincode 1, we have made `Configu
 
 You may wish to stick with `serde` when migrating to bincode 2, for example if you are using serde-exclusive derive features such as `#[serde(deserialize_with)]`.
 
-If so, make sure to include bincode 2 with the `serde` feature enabled.
+If so, make sure to include bincode 2 with the `serde` feature enabled, and use the `bincode::serde::*` functions instead of `bincode::*` as described below:
 
 ```toml
 [dependencies]


### PR DESCRIPTION
This past week I ported a crate from bincode1 to bincode2. I [had some difficulty](https://github.com/bincode-org/bincode/issues/714) because I took the "migrate serde to bincode-derive" path, which was not appropriate for my application. I was following the migration guide, but I misread it.

I would like to recommend some minor language tweaks to make the migration guide more resistant to misinterpretation. Proposed language is attached, but I don't care if you use my specific language. I do suggest you make *some* form of the following changes:

* Make it clearer that the "Migrating with `serde`" and "Migrating to `bincode-derive`" sections describe *exclusive* options.
* Describe *why* someone might want to intentionally migrate with serde.

This would have helped me do my porting correctly the first time.