### PR TITLE
Reader: use BufRead instead of BufReader

### DIFF
--- a/src/de/read.rs
+++ b/src/de/read.rs
@@ -31,26 +31,6 @@ pub trait Reader {
     fn consume(&mut self, _: usize) {}
 }
 
-impl<T> Reader for &mut T
-where
-    T: Reader,
-{
-    #[inline]
-    fn read(&mut self, bytes: &mut [u8]) -> Result<(), DecodeError> {
-        (**self).read(bytes)
-    }
-
-    #[inline]
-    fn peek_read(&mut self, n: usize) -> Option<&[u8]> {
-        (**self).peek_read(n)
-    }
-
-    #[inline]
-    fn consume(&mut self, n: usize) {
-        (*self).consume(n)
-    }
-}
-
 /// A reader for borrowed data. Implementors of this must also implement the [Reader] trait. See the module documentation for more information.
 pub trait BorrowReader<'storage>: Reader {
     /// Read exactly `length` bytes and return a slice to this data. If not enough bytes could be read, an error should be returned.

--- a/src/features/impl_std.rs
+++ b/src/features/impl_std.rs
@@ -57,9 +57,9 @@ where
     }
 }
 
-impl<R> Reader for std::io::BufReader<R>
+impl<R> Reader for R
 where
-    R: std::io::Read,
+    R: std::io::BufRead,
 {
     fn read(&mut self, bytes: &mut [u8]) -> Result<(), DecodeError> {
         self.read_exact(bytes).map_err(|inner| DecodeError::Io {
@@ -70,7 +70,7 @@ where
 
     #[inline]
     fn peek_read(&mut self, n: usize) -> Option<&[u8]> {
-        self.buffer().get(..n)
+        self.fill_buf().ok().map(|b| &b[..n])
     }
 
     #[inline]


### PR DESCRIPTION
This makes it, so any `BufRead` implementation can be used with `Reader`, not just `BufReader`.
This is very useful for my [fuse-ufs](https://github.com/realchonk/fuse-ufs) project.

The `&mut` implementation was removed, because [`BufRead` already provides one](https://doc.rust-lang.org/std/io/trait.BufRead.html#impl-BufRead-for-%26mut+B).
