### PR TITLE
Add prerelease warning to readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # Bincode
-
+### The following information is for the prerelease 2.x versions of this library. The stable branch can be found [here](https://github.com/bincode-org/bincode/tree/v1.x).
 <img align="right" src="./logo.svg" />
 
 [![CI](https://github.com/bincode-org/bincode/workflows/CI/badge.svg)](https://github.com/bincode-org/bincode/actions)


### PR DESCRIPTION
It will be helpful to point users of the library to code examples that will work for them.

I started off with a `cargo add` and tried to use the example in the readme as guidance and ran into problems. When I started digging in to see the problem I saw #726 which seems to have had similar expectations.