### PR TITLE
Expose types implementing `serde::Serializer` and `Deserializer`

### DIFF
--- a/src/features/serde/de_owned.rs
+++ b/src/features/serde/de_owned.rs
@@ -1,13 +1,13 @@
-use super::DecodeError as SerdeDecodeError;
+use super::{de_borrowed::borrow_decode_from_slice, DecodeError as SerdeDecodeError};
 use crate::{
     config::Config,
     de::{read::Reader, Decode, Decoder, DecoderImpl},
     error::DecodeError,
-    IoReader,
 };
 use serde::de::*;
 
-use super::de_borrowed::borrow_decode_from_slice;
+#[cfg(feature = "std")]
+use crate::features::IoReader;
 
 /// Serde decoder encapsulating an owned reader.
 pub struct OwnedSerdeDecoder<DE: Decoder> {

--- a/src/features/serde/de_owned.rs
+++ b/src/features/serde/de_owned.rs
@@ -1,10 +1,54 @@
 use super::DecodeError as SerdeDecodeError;
 use crate::{
     config::Config,
-    de::{read::Reader, Decode, Decoder},
+    de::{read::Reader, Decode, Decoder, DecoderImpl},
     error::DecodeError,
+    IoReader,
 };
 use serde::de::*;
+
+use super::de_borrowed::borrow_decode_from_slice;
+
+/// Serde decoder encapsulating an owned reader.
+pub struct OwnedSerdeDecoder<DE: Decoder> {
+    pub(super) de: DE,
+}
+
+impl<DE: Decoder> OwnedSerdeDecoder<DE> {
+    /// Return a type implementing `serde::Deserializer`.
+    pub fn as_deserializer<'a>(
+        &'a mut self,
+    ) -> impl for<'de> serde::Deserializer<'de, Error = DecodeError> + 'a {
+        SerdeDecoder { de: &mut self.de }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'r, C: Config, R: std::io::Read> OwnedSerdeDecoder<DecoderImpl<IoReader<&'r mut R>, C>> {
+    /// Creates the decoder from an `std::io::Read` implementor.
+    pub fn from_std_read(
+        src: &'r mut R,
+        config: C,
+    ) -> OwnedSerdeDecoder<DecoderImpl<IoReader<&'r mut R>, C>>
+    where
+        C: Config,
+    {
+        let reader = IoReader::new(src);
+        let decoder = DecoderImpl::new(reader, config);
+        Self { de: decoder }
+    }
+}
+
+impl<C: Config, R: Reader> OwnedSerdeDecoder<DecoderImpl<R, C>> {
+    /// Creates the decoder from a [`Reader`] implementor.
+    pub fn from_reader(reader: R, config: C) -> OwnedSerdeDecoder<DecoderImpl<R, C>>
+    where
+        C: Config,
+    {
+        let decoder = DecoderImpl::new(reader, config);
+        Self { de: decoder }
+    }
+}
 
 /// Attempt to decode a given type `D` from the given slice. Returns the decoded output and the amount of bytes read.
 ///
@@ -19,12 +63,7 @@ where
     D: DeserializeOwned,
     C: Config,
 {
-    let reader = crate::de::read::SliceReader::new(slice);
-    let mut decoder = crate::de::DecoderImpl::new(reader, config);
-    let serde_decoder = SerdeDecoder { de: &mut decoder };
-    let result = D::deserialize(serde_decoder)?;
-    let bytes_read = slice.len() - decoder.reader().slice.len();
-    Ok((result, bytes_read))
+    borrow_decode_from_slice(slice, config)
 }
 
 /// Decode type `D` from the given reader with the given `Config`. The reader can be any type that implements `std::io::Read`, e.g. `std::fs::File`.
@@ -34,14 +73,13 @@ where
 /// [config]: ../config/index.html
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-pub fn decode_from_std_read<D: DeserializeOwned, C: Config, R: std::io::Read>(
-    src: &mut R,
+pub fn decode_from_std_read<'r, D: DeserializeOwned, C: Config, R: std::io::Read>(
+    src: &'r mut R,
     config: C,
 ) -> Result<D, DecodeError> {
-    let reader = crate::IoReader::new(src);
-    let mut decoder = crate::de::DecoderImpl::new(reader, config);
-    let serde_decoder = SerdeDecoder { de: &mut decoder };
-    D::deserialize(serde_decoder)
+    let mut serde_decoder =
+        OwnedSerdeDecoder::<DecoderImpl<IoReader<&'r mut R>, C>>::from_std_read(src, config);
+    D::deserialize(serde_decoder.as_deserializer())
 }
 
 /// Attempt to decode a given type `D` from the given [Reader].
@@ -53,13 +91,12 @@ pub fn decode_from_reader<D: DeserializeOwned, R: Reader, C: Config>(
     reader: R,
     config: C,
 ) -> Result<D, DecodeError> {
-    let mut decoder = crate::de::DecoderImpl::<_, C>::new(reader, config);
-    let serde_decoder = SerdeDecoder { de: &mut decoder };
-    D::deserialize(serde_decoder)
+    let mut serde_decoder = OwnedSerdeDecoder::<DecoderImpl<R, C>>::from_reader(reader, config);
+    D::deserialize(serde_decoder.as_deserializer())
 }
 
-pub(crate) struct SerdeDecoder<'a, DE: Decoder> {
-    pub(crate) de: &'a mut DE,
+pub(super) struct SerdeDecoder<'a, DE: Decoder> {
+    pub(super) de: &'a mut DE,
 }
 
 impl<'de, DE: Decoder> Deserializer<'de> for SerdeDecoder<'_, DE> {


### PR DESCRIPTION
This is sort of a proof-of-concept PR, I would like your input on it even though it's still in draft.

The goal here is to expose types implementing `serde::Serializer` and `Deserializer` so that `bincode` could be used with https://docs.rs/erased-serde. `Serializer` is straightforward, but `Deserializer` can be exposed in two ways:
- Expose some type `D`, where `for<'a> &'a mut D: Deserializer<'de>`. This is done e.g. [in `postcard`](https://docs.rs/postcard/latest/postcard/struct.Deserializer.html). The problem here is that using such types generically involves passing around an ugly bound on lifetimes, which [cannot be encapsulated in a trait](https://github.com/rust-lang/rust/issues/50346). Also, dealing with such types in `erased_serde` is [somewhat complicated](https://github.com/dtolnay/erased-serde/issues/107) (albeit possible).
- A much more convenient API is exposing a type `D: Deserializer<'de>`. The downside of this is that in the format implementations (like `bincode`) `serde::Deserializer` is generally implemented for `&mut Something`, or a wrapper of it (`SerdeDecoder` in `bincode`'s case), because it has to be passed to nested list/struct/etc deserializers. So creating another implementation for `D` involves writing down the massive trait impl one more time.

So, I would like your input on the way to proceed with this. I see the following options:
1. This is not something you want to see in `bincode` at all. Feel free to close the PR then.
2. Expose a type `D`, where `for<'a> &'a mut D: Deserializer<'de>`. This requires minimum changes, but creates problems for the users, as described above.  
3. Expose a type `D: Deserializer<'de>`, writing down another `Deserializer` impl (of which there are already two in the codebase).
4. Expose a type `D: Deserializer<'de>`, relying on a helper crate that I made (https://docs.rs/serde-persistent-deserializer), which is implemented in this PR. The reason I put it there is that I want to create a similar PR for other formats, and I would like to avoid writing `Deserializer` impls in each of them. I understand if you want to minimize the number of dependencies, then the contents of that crate can be brought in verbatim.

(This PR currently does not expose `Serializer`, but that's easy, and I'll add it later if you decide not to go with Option 1).

A few things about the PR itself. 
- I would like to remove the `Deserializer` impl in `de_borrowed`, and it's almost possible by just replacing `de_borrowed::SerdeDecoder` with `de_owned::SerdeDecoder` , but a single test fails because these impls are slightly different. I am not sure if it's possible to merge them.
- I am not sure I understand the comment in `de_owned::decode_from_slice()` ("Note that this does not work with borrowed types like `&str` or `&[u8]`. For that use [borrow_decode_from_slice].") Seems to be working fine, as I can just call `de_borrowed::borrow_decode_from_slice()` from it.
