### PR TITLE
Implement basic traits for `Compat` and `BorrowCompat`

### DIFF
--- a/src/features/serde/mod.rs
+++ b/src/features/serde/mod.rs
@@ -179,6 +179,7 @@ impl serde::ser::Error for crate::error::EncodeError {
 /// [Encode]: ../enc/trait.Encode.html
 /// [DeserializeOwned]: https://docs.rs/serde/1/serde/de/trait.DeserializeOwned.html
 /// [Serialize]: https://docs.rs/serde/1/serde/trait.Serialize.html
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Compat<T>(pub T);
 
 impl<T> crate::Decode for Compat<T>
@@ -240,6 +241,7 @@ where
 /// [Encode]: ../enc/trait.Encode.html
 /// [Deserialize]: https://docs.rs/serde/1/serde/de/trait.Deserialize.html
 /// [Serialize]: https://docs.rs/serde/1/serde/trait.Serialize.html
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct BorrowCompat<T>(pub T);
 
 impl<'de, T> crate::de::BorrowDecode<'de> for BorrowCompat<T>


### PR DESCRIPTION
Wrapper types `Compat` and `BorrowCompat` do not introduce any kind of complexity or usage context to the inner type, and their only purpose is to provide an implementation for `bincode` traits.

So, it would be nice to make them as flexible as possible by deriving all common traits:
```rust
#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
```