### PR TITLE
Use qualified path for Result::Ok in bincode_derive

### DIFF
--- a/derive/src/derive_enum.rs
+++ b/derive/src/derive_enum.rs
@@ -124,7 +124,7 @@ impl DeriveEnum {
                                     }
                                 }
                             }
-                            body.push_parsed("Ok(())")?;
+                            body.push_parsed("core::result::Result::Ok(())")?;
                             Ok(())
                         })?;
                         match_body.punct(',');
@@ -274,7 +274,7 @@ impl DeriveEnum {
                                 variant_case.push(variant_index.remove(0));
                             }
                             variant_case.puncts("=>");
-                            variant_case.ident_str("Ok");
+                            variant_case.push_parsed("core::result::Result::Ok")?;
                             variant_case.group(Delimiter::Parenthesis, |variant_case_body| {
                                 // Self::Variant { }
                                 // Self::Variant { 0: ..., 1: ... 2: ... },
@@ -384,7 +384,7 @@ impl DeriveEnum {
                                 variant_case.push(variant_index.remove(0));
                             }
                             variant_case.puncts("=>");
-                            variant_case.ident_str("Ok");
+                            variant_case.push_parsed("core::result::Result::Ok")?;
                             variant_case.group(Delimiter::Parenthesis, |variant_case_body| {
                                 // Self::Variant { }
                                 // Self::Variant { 0: ..., 1: ... 2: ... },

--- a/derive/src/derive_struct.rs
+++ b/derive/src/derive_struct.rs
@@ -56,7 +56,7 @@ impl DeriveStruct {
                         }
                     }
                 }
-                fn_body.push_parsed("Ok(())")?;
+                fn_body.push_parsed("core::result::Result::Ok(())")?;
                 Ok(())
             })?;
         Ok(())
@@ -95,7 +95,7 @@ impl DeriveStruct {
             .with_return_type(format!("core::result::Result<Self, {}::error::DecodeError>", crate_name))
             .body(|fn_body| {
                 // Ok(Self {
-                fn_body.ident_str("Ok");
+                fn_body.push_parsed("core::result::Result::Ok")?;
                 fn_body.group(Delimiter::Parenthesis, |ok_group| {
                     ok_group.ident_str("Self");
                     ok_group.group(Delimiter::Brace, |struct_body| {
@@ -174,7 +174,7 @@ impl DeriveStruct {
             .with_return_type(format!("core::result::Result<Self, {}::error::DecodeError>", crate_name))
             .body(|fn_body| {
                 // Ok(Self {
-                fn_body.ident_str("Ok");
+                fn_body.push_parsed("core::result::Result::Ok")?;
                 fn_body.group(Delimiter::Parenthesis, |ok_group| {
                     ok_group.ident_str("Self");
                     ok_group.group(Delimiter::Brace, |struct_body| {

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -403,6 +403,23 @@ fn test_enum_with_generics_roundtrip() {
     assert_eq!(start, decoded);
 }
 
+mod derive_with_polluted_scope {
+    #[allow(dead_code)]
+    #[allow(non_snake_case)]
+    fn Ok() {}
+
+    #[derive(bincode::Encode, bincode::Decode)]
+    struct A {
+        a: u32,
+    }
+
+    #[derive(bincode::Encode, bincode::Decode)]
+    enum B {
+        A,
+        B,
+    }
+}
+
 #[cfg(feature = "alloc")]
 mod zoxide {
     extern crate alloc;


### PR DESCRIPTION
fixes https://github.com/bincode-org/bincode/issues/756 by using a qualified path for `core::result::Result::Ok`.