### PR TITLE
derive `Debug` and simplify marker structs in config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -200,7 +200,7 @@ where
 }
 
 /// Encodes all integer types in big endian.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct BigEndian {}
 
 impl InternalEndianConfig for BigEndian {
@@ -208,7 +208,7 @@ impl InternalEndianConfig for BigEndian {
 }
 
 /// Encodes all integer types in little endian.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct LittleEndian {}
 
 impl InternalEndianConfig for LittleEndian {
@@ -216,7 +216,7 @@ impl InternalEndianConfig for LittleEndian {
 }
 
 /// Use fixed-size integer encoding.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Fixint {}
 
 impl InternalIntEncodingConfig for Fixint {
@@ -224,7 +224,7 @@ impl InternalIntEncodingConfig for Fixint {
 }
 
 /// Use variable integer encoding.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Varint {}
 
 impl InternalIntEncodingConfig for Varint {
@@ -232,14 +232,14 @@ impl InternalIntEncodingConfig for Varint {
 }
 
 /// Sets an unlimited byte limit.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct NoLimit {}
 impl InternalLimitConfig for NoLimit {
     const LIMIT: Option<usize> = None;
 }
 
 /// Sets the byte limit to N.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Limit<const N: usize> {}
 impl<const N: usize> InternalLimitConfig for Limit<N> {
     const LIMIT: Option<usize> = Some(N);

--- a/src/config.rs
+++ b/src/config.rs
@@ -201,7 +201,7 @@ where
 
 /// Encodes all integer types in big endian.
 #[derive(Copy, Clone, Debug)]
-pub struct BigEndian {}
+pub struct BigEndian;
 
 impl InternalEndianConfig for BigEndian {
     const ENDIAN: Endianness = Endianness::Big;
@@ -209,7 +209,7 @@ impl InternalEndianConfig for BigEndian {
 
 /// Encodes all integer types in little endian.
 #[derive(Copy, Clone, Debug)]
-pub struct LittleEndian {}
+pub struct LittleEndian;
 
 impl InternalEndianConfig for LittleEndian {
     const ENDIAN: Endianness = Endianness::Little;
@@ -217,7 +217,7 @@ impl InternalEndianConfig for LittleEndian {
 
 /// Use fixed-size integer encoding.
 #[derive(Copy, Clone, Debug)]
-pub struct Fixint {}
+pub struct Fixint;
 
 impl InternalIntEncodingConfig for Fixint {
     const INT_ENCODING: IntEncoding = IntEncoding::Fixed;
@@ -225,7 +225,7 @@ impl InternalIntEncodingConfig for Fixint {
 
 /// Use variable integer encoding.
 #[derive(Copy, Clone, Debug)]
-pub struct Varint {}
+pub struct Varint;
 
 impl InternalIntEncodingConfig for Varint {
     const INT_ENCODING: IntEncoding = IntEncoding::Variable;
@@ -233,14 +233,14 @@ impl InternalIntEncodingConfig for Varint {
 
 /// Sets an unlimited byte limit.
 #[derive(Copy, Clone, Debug)]
-pub struct NoLimit {}
+pub struct NoLimit;
 impl InternalLimitConfig for NoLimit {
     const LIMIT: Option<usize> = None;
 }
 
 /// Sets the byte limit to N.
 #[derive(Copy, Clone, Debug)]
-pub struct Limit<const N: usize> {}
+pub struct Limit<const N: usize>;
 impl<const N: usize> InternalLimitConfig for Limit<N> {
     const LIMIT: Option<usize> = Some(N);
 }


### PR DESCRIPTION
The `Configuration` struct derives the `Debug` trait which can not be satisfied by default since the marker types such as `LittleEndian` etc. do not implement this `Debug` trait.
This PR fixes that.

Furthermore, we can use a more simplified notation, omitting empty brackets when using marker structs.
```rust
struct Imarkthings {}
struct Ialsomarkthings;
```