### PR TITLE
Implement core::error::Error for error types.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -63,6 +63,27 @@ impl core::fmt::Display for EncodeError {
     }
 }
 
+impl core::error::Error for EncodeError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::RefCellAlreadyBorrowed { inner, .. } => Some(inner),
+            #[cfg(feature = "std")]
+            Self::Io { inner, .. } => Some(inner),
+            #[cfg(feature = "std")]
+            Self::InvalidSystemTime { inner, .. } => Some(inner),
+            _ => None,
+        }
+    }
+}
+impl core::error::Error for DecodeError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Utf8 { inner } => Some(inner),
+            _ => None,
+        }
+    }
+}
+
 /// Errors that can be encountered by decoding a type
 #[non_exhaustive]
 #[derive(Debug)]

--- a/src/features/impl_std.rs
+++ b/src/features/impl_std.rs
@@ -412,25 +412,6 @@ impl<Context> Decode<Context> for SocketAddrV6 {
 }
 impl_borrow_decode!(SocketAddrV6);
 
-impl std::error::Error for EncodeError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::RefCellAlreadyBorrowed { inner, .. } => Some(inner),
-            Self::Io { inner, .. } => Some(inner),
-            Self::InvalidSystemTime { inner, .. } => Some(inner),
-            _ => None,
-        }
-    }
-}
-impl std::error::Error for DecodeError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::Utf8 { inner } => Some(inner),
-            _ => None,
-        }
-    }
-}
-
 impl<K, V, S> Encode for HashMap<K, V, S>
 where
     K: Encode,

--- a/src/features/serde/mod.rs
+++ b/src/features/serde/mod.rs
@@ -114,9 +114,6 @@ impl serde::de::Error for crate::error::DecodeError {
     }
 }
 
-#[cfg(not(feature = "std"))]
-impl serde::de::StdError for crate::error::DecodeError {}
-
 #[cfg(not(feature = "alloc"))]
 impl serde::de::Error for crate::error::DecodeError {
     fn custom<T>(_: T) -> Self
@@ -168,9 +165,6 @@ impl serde::ser::Error for crate::error::EncodeError {
         Self::OtherString(msg.to_string())
     }
 }
-
-#[cfg(not(feature = "std"))]
-impl serde::de::StdError for crate::error::EncodeError {}
 
 #[cfg(not(feature = "alloc"))]
 impl serde::ser::Error for crate::error::EncodeError {


### PR DESCRIPTION
With the error trait being moved from `std` to `core` in rust 1.81, implementing `core::error::Error` allows the error trait to be used in `[no_std]` environments for these types.