### PR TITLE
Fix Typo in BorrowDecoder Documentation

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -259,7 +259,7 @@ pub trait BorrowDecoder<'de>: Decoder {
     /// The concrete [BorrowReader] type
     type BR: BorrowReader<'de>;
 
-    /// Rerturns a mutable reference to the borrow reader
+    /// Returns a mutable reference to the borrow reader
     fn borrow_reader(&mut self) -> &mut Self::BR;
 }
 


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the documentation comment for the borrow_reader method in BorrowDecoder. The word "Rerturns" has been updated to "Returns" for improved clarity and professionalism. 