### PR TITLE
Fix Typos in Documentation Comments

### DIFF
--- a/src/de/read.rs
+++ b/src/de/read.rs
@@ -51,7 +51,7 @@ where
     }
 }
 
-/// A reader for borrowed data. Implementors of this must also implement the [Reader] trait. See the module documentation for more information.
+/// A reader for borrowed data. Implementers of this must also implement the [Reader] trait. See the module documentation for more information.
 pub trait BorrowReader<'storage>: Reader {
     /// Read exactly `length` bytes and return a slice to this data. If not enough bytes could be read, an error should be returned.
     ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-//! Errors that can be encounting by Encoding and Decoding.
+//! Errors that can be encountering by Encoding and Decoding.
 
 /// Errors that can be encountered by encoding a type
 #[non_exhaustive]


### PR DESCRIPTION


**Description:**  
This PR corrects minor typos in documentation comments within the codebase:
- Replaces "encounting" with "encountering" in error.rs.
- Fixes "Implementors" formatting in read.rs.

